### PR TITLE
Normalize gacha rarity probabilities

### DIFF
--- a/server/gacha/routes.js
+++ b/server/gacha/routes.js
@@ -9,10 +9,11 @@ router.use(requireAuth);
 
 // Probabilidades por raridade (soma 1.0)
 const RARITY_ORDER = ['COMMON', 'RARE', 'SUPER_RARE', 'LEGENDARY', 'MYTHIC', 'ULTIMATE'];
+// valores normalizados para garantir que a soma total seja 1.0
 const RARITY_PROB = [
-  { rarity: 'COMMON',      p: 0.75 },
-  { rarity: 'RARE',        p: 0.18 },
-  { rarity: 'SUPER_RARE',  p: 0.06 },
+  { rarity: 'COMMON',      p: 0.74962 },
+  { rarity: 'RARE',        p: 0.17991 },
+  { rarity: 'SUPER_RARE',  p: 0.05997 },
   { rarity: 'LEGENDARY',   p: 0.009 },
   { rarity: 'MYTHIC',      p: 0.001 },
   { rarity: 'ULTIMATE',    p: 0.0005 },


### PR DESCRIPTION
## Summary
- normalize gacha rarity probabilities so they sum to 1.0
- document normalized values for clarity

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a749de90c883279a78e2bc54eed2a3