### PR TITLE
feat: add team management scaffold

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -779,7 +779,10 @@
     <section id="view-house" class="view ui-frame bg-dither">
       <button class="btn-back" data-back>← BACK</button>
       <div class="ui-title">HOUSE</div>
-      <div style="padding:16px">🏠 Recuperação e buffs por mobília.</div>
+      <div style="padding:16px">
+        <button id="openTeam" class="btn-logout">Manage Team</button>
+        <div id="teamList" style="margin-top:8px"></div>
+      </div>
     </section>
   </main>
 
@@ -920,7 +923,19 @@
   </script>
 
   <!-- Profile / Equip Modal (layout compacto com skills à direita) -->
-  <div id="profileModal" class="pf-overlay" aria-hidden="true" style="display:none">
+  <div id="teamModal" class="pf-overlay" aria-hidden="true" style="display:none">
+  <div class="pf-dialog" role="dialog" aria-modal="true">
+    <button id="teamClose" class="pf-close" aria-label="Close">✕</button>
+    <h2 class="pf-title">Team</h2>
+    <div id="teamSlots" class="pf-skill-scroll" style="margin-bottom:8px;"></div>
+    <div id="teamHeroes" class="pf-skill-scroll" style="max-height:200px;"></div>
+    <div class="pf-footer">
+      <button id="teamSave" class="pf-btn">Save</button>
+    </div>
+  </div>
+</div>
+
+<div id="profileModal" class="pf-overlay" aria-hidden="true" style="display:none">
     <div class="pf-dialog" role="dialog" aria-modal="true">
       <button class="pf-close" aria-label="Close">✕</button>
 

--- a/client/js/boot.js
+++ b/client/js/boot.js
@@ -2,6 +2,7 @@
 import { API, getCsrf, apiGet } from './api.js';
 import { doLogin, doRegister, doLogout } from './auth.js';
 import { bindGachaUI } from './gacha.js';
+import { bindTeamUI } from './team.js';
 import { initLoginFx, stopLoginFx, celebrate } from './login_fx.js';
 import { bindProfileModal, setupInventoryOpen } from './player_profile.js'; // PERFIL
 
@@ -83,6 +84,7 @@ const ctx = {
 
 // ===== Estado de sessão =====
 let __profile = null;
+let teamUI = null;
 window.__isAuth = false;
 
 // HUD centralizado
@@ -151,6 +153,9 @@ async function showApp(profile) {
 
   updateHud(profile);
   await gacha.init(profile);
+
+  if (!teamUI) teamUI = bindTeamUI();
+  await teamUI.refresh();
 
   // === Bind do modal de perfil (uma única vez)
   if (!__profileModalBound) {

--- a/client/js/team.js
+++ b/client/js/team.js
@@ -1,0 +1,99 @@
+import { API, apiGet, apiPost } from './api.js';
+
+export function bindTeamUI() {
+  const openBtn = document.getElementById('openTeam');
+  const modal = document.getElementById('teamModal');
+  const slotsEl = document.getElementById('teamSlots');
+  const heroesEl = document.getElementById('teamHeroes');
+  const saveBtn = document.getElementById('teamSave');
+  const closeBtn = document.getElementById('teamClose');
+  const listEl = document.getElementById('teamList');
+
+  let heroes = [];
+  const team = { 1: null, 2: null, 3: null };
+  let currentSlot = 1;
+
+  async function refresh() {
+    const me = await apiGet(`${API}/api/player/me`);
+    heroes = me?.heroes || [];
+    const t = await apiGet(`${API}/api/team`);
+    team[1] = team[2] = team[3] = null;
+    for (const row of t.team || []) team[row.slot] = row.heroId;
+    renderTeamList();
+  }
+
+  function renderTeamList() {
+    if (!listEl) return;
+    listEl.innerHTML = '';
+    for (let s = 1; s <= 3; s++) {
+      const hero = heroes.find(h => h.id === team[s]);
+      const div = document.createElement('div');
+      div.textContent = `Slot ${s}: ${hero ? hero.name : '-'}`;
+      listEl.appendChild(div);
+    }
+  }
+
+  function renderModal() {
+    if (!slotsEl || !heroesEl) return;
+    slotsEl.innerHTML = '';
+    for (let s = 1; s <= 3; s++) {
+      const hero = heroes.find(h => h.id === team[s]);
+      const btn = document.createElement('button');
+      btn.className = 'pf-btn';
+      btn.textContent = hero ? `Slot ${s}: ${hero.name}` : `Slot ${s}: —`;
+      btn.onclick = () => { currentSlot = s; };
+      slotsEl.appendChild(btn);
+    }
+    heroesEl.innerHTML = '';
+    heroes.forEach(h => {
+      const b = document.createElement('button');
+      b.className = 'pf-btn';
+      b.textContent = h.name;
+      b.onclick = () => {
+        if (currentSlot) {
+          team[currentSlot] = h.id;
+          renderModal();
+        }
+      };
+      heroesEl.appendChild(b);
+    });
+  }
+
+  async function save() {
+    const payload = { team: [] };
+    for (let s = 1; s <= 3; s++) {
+      if (team[s]) payload.team.push({ slot: s, heroId: team[s] });
+    }
+    await apiPost(`${API}/api/team`, payload);
+    renderTeamList();
+    close();
+  }
+
+  function open() {
+    if (!modal) return;
+    renderModal();
+    modal.style.display = '';
+    modal.classList.add('show');
+    modal.setAttribute('aria-hidden', 'false');
+  }
+
+  function close() {
+    if (!modal) return;
+    modal.classList.remove('show');
+    modal.setAttribute('aria-hidden', 'true');
+    modal.style.display = 'none';
+  }
+
+  openBtn?.addEventListener('click', async () => {
+    try {
+      await refresh();
+      open();
+    } catch (err) {
+      console.error('team refresh', err);
+    }
+  });
+  saveBtn?.addEventListener('click', save);
+  closeBtn?.addEventListener('click', close);
+
+  return { refresh, renderTeamList };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ const authRoutes = require('./auth/routes');
 const playerRoutes = require('./player/routes');
 const gachaRoutes = require('./gacha/routes');
 const catalogRoutes = require('./routes/catalog');
+const teamRoutes = require('./team/routes');
 
 // ========= CONFIG =========
 const NODE_ENV = process.env.NODE_ENV || 'development';
@@ -48,6 +49,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api', catalogRoutes);
 app.use('/api/player', requireAuth, playerRoutes);
 app.use('/api/gacha', requireAuth, gachaRoutes);
+app.use('/api/team', requireAuth, teamRoutes);
 
 // skills (suas rotas já existentes — mantidas)
 app.use('/api/skills', require('./skills/routes'));

--- a/server/models/migrate.js
+++ b/server/models/migrate.js
@@ -31,6 +31,25 @@ async function migrate() {
     )
   `);
 
+  await run(`
+    CREATE TABLE IF NOT EXISTS player_team(
+      player_id TEXT NOT NULL,
+      hero_id INTEGER NOT NULL,
+      slot INTEGER NOT NULL,
+      PRIMARY KEY(player_id, slot),
+      FOREIGN KEY(player_id) REFERENCES players(id),
+      FOREIGN KEY(hero_id) REFERENCES player_heroes(id)
+    )
+  `);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS player_team_config(
+      player_id TEXT PRIMARY KEY,
+      config_json TEXT NOT NULL DEFAULT '{}',
+      FOREIGN KEY(player_id) REFERENCES players(id)
+    )
+  `);
+
   // retrocompat: garantir password_hash
   const pCols = new Set((await all(`PRAGMA table_info(players)`)).map(c => c.name));
   if (!pCols.has('password_hash')) await run(`ALTER TABLE players ADD COLUMN password_hash TEXT DEFAULT ''`);

--- a/server/team/routes.js
+++ b/server/team/routes.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const { all, run } = require('../models/db');
+
+const router = express.Router();
+
+// GET /api/team - retorna equipe atual (slots 1-3)
+router.get('/', async (req, res) => {
+  try {
+    const rows = await all(
+      `SELECT slot, hero_id AS heroId FROM player_team WHERE player_id = ? ORDER BY slot`,
+      [req.user.id]
+    );
+    res.json({ team: rows });
+  } catch (err) {
+    console.error('team get', err);
+    res.status(500).json({ error: 'Falha ao obter team' });
+  }
+});
+
+// POST /api/team - define equipe
+router.post('/', async (req, res) => {
+  try {
+    const playerId = req.user.id;
+    const team = Array.isArray(req.body.team) ? req.body.team : [];
+
+    // valida slots únicos e heróis pertencentes ao jogador
+    const heroes = await all(`SELECT id FROM player_heroes WHERE playerId = ?`, [playerId]);
+    const validIds = new Set(heroes.map(h => h.id));
+
+    const usedSlots = new Set();
+    for (const t of team) {
+      if (![1,2,3].includes(Number(t.slot))) return res.status(400).json({ error: 'slot inválido' });
+      if (usedSlots.has(t.slot)) return res.status(400).json({ error: 'slot duplicado' });
+      usedSlots.add(t.slot);
+      if (!validIds.has(Number(t.heroId))) return res.status(400).json({ error: 'herói inválido' });
+    }
+
+    await run(`DELETE FROM player_team WHERE player_id = ?`, [playerId]);
+    for (const t of team) {
+      await run(
+        `INSERT INTO player_team (player_id, hero_id, slot) VALUES (?, ?, ?)`,
+        [playerId, t.heroId, t.slot]
+      );
+    }
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('team post', err);
+    res.status(500).json({ error: 'Falha ao salvar team' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add player_team tables and API endpoints
- hook team routes into server
- provide basic Team modal and House integration
- fix Team modal not showing by toggling overlay visibility correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75d20eff08327afc3e5b77b32237b