### PR TITLE
Clamp hero reach and share live positions with AI

### DIFF
--- a/client/js/pos-publisher.js
+++ b/client/js/pos-publisher.js
@@ -1,7 +1,7 @@
 // /client/js/pos-publisher.js
 // Publica posição quantizada no centro do tile (32px) via WS,
 // com flush ao parar, flush periódico e flush ao fechar a aba.
-// Ajustado para respeitar o MIN_STEP_MS do servidor e evitar "rubber-banding".
+// Mantém o ritmo alinhado ao speed-cap servidor (≈180px/s) para evitar "rubber-banding".
 
 import { wsSend } from './ws/singleton.js';
 
@@ -16,7 +16,7 @@ const state = {
   idleTimer: null,
 };
 
-// Server aceita 1 passo/≈106ms (32px / 180px/s × 0.60). Aqui damos folga.
+// Server aceita 1 passo/≈124ms (32px / 180px/s × 0.70). Aqui damos folga.
 // Você pode sobrepor via window.ENV.MIN_TILE_MS.
 const MIN_TILE_MS = Number(window.ENV?.MIN_TILE_MS || 130);
 

--- a/server/balance/config.js
+++ b/server/balance/config.js
@@ -54,9 +54,9 @@ module.exports = {
     SWORD:    envNum('SWORD_RANGE_TILES', 1),
     AXE:      envNum('AXE_RANGE_TILES', 1),
     CLUB:     envNum('CLUB_RANGE_TILES', 1),
-    BOW:      envNum('BOW_RANGE_TILES', 5),
-    DISTANCE: envNum('DISTANCE_RANGE_TILES', envNum('BOW_RANGE_TILES', 5)),
-    MAGIC:    envNum('MAGIC_RANGE_TILES', 8),
+    BOW:      envNum('BOW_RANGE_TILES', 4),
+    DISTANCE: envNum('DISTANCE_RANGE_TILES', envNum('BOW_RANGE_TILES', 4)),
+    MAGIC:    envNum('MAGIC_RANGE_TILES', 4),
     MONSTER:  envNum('MONSTER_RANGE_TILES', 1), // << claro e tunável
   },
 

--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -12,6 +12,7 @@
   const { hasLineOfSight } = require('./los');
   // const { inReachPx } = require('./geom');
   const { applyMobHit } = require('./service');
+  const { listFreshHeroesByMap } = require('../player/live_positions');
 
   const PX_PER_TILE = 32;
 
@@ -27,7 +28,7 @@
   const CHASE_SPEED_PX_S = 90;          // px/s
   const REPATH_MS = 500;                // recálculo de direção
   const GIVEUP_MS = 8000;               // desiste se perder o alvo por muito tempo
-  const ONLINE_RECENT_MS = 2000;       // presença considerada “viva” nos últimos 2s
+  const ONLINE_RECENT_MS = 4000;       // presença considerada “viva” nos últimos 4s
 
   // Anti-hit fantasma (idades máximas aceitáveis das posições)
   const STALE_HERO_MS = 400;           // herói precisa ter pos ≤ 400ms
@@ -61,8 +62,43 @@
     return hasLineOfSight(losGrid, aCx, aCy, bCx, bCy);
   }
 
-    function chebyPx(ax, ay, bx, by) {
+  function chebyPx(ax, ay, bx, by) {
     return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
+  }
+
+  function normalizeMonsterPos({ x, y, spawnRect }) {
+    let rawX = Number(x ?? 0);
+    let rawY = Number(y ?? 0);
+    if (!Number.isFinite(rawX)) rawX = 0;
+    if (!Number.isFinite(rawY)) rawY = 0;
+
+    let px = Math.round(rawX);
+    let py = Math.round(rawY);
+
+    if (spawnRect && Number.isFinite(spawnRect.x) && Number.isFinite(spawnRect.y)) {
+      const sx = Number(spawnRect.x);
+      const sy = Number(spawnRect.y);
+      const rawW = Number(spawnRect.w);
+      const rawH = Number(spawnRect.h);
+      const sw = Number.isFinite(rawW) && rawW > 0 ? rawW : PX_PER_TILE;
+      const sh = Number.isFinite(rawH) && rawH > 0 ? rawH : PX_PER_TILE;
+
+      const centerX = sx + sw / 2;
+      const centerY = sy + sh / 2;
+
+      const rawDist = Math.hypot(px - centerX, py - centerY);
+
+      const tilePx = Math.round(rawX) * PX_PER_TILE + PX_PER_TILE / 2;
+      const tilePy = Math.round(rawY) * PX_PER_TILE + PX_PER_TILE / 2;
+      const tileDist = Math.hypot(tilePx - centerX, tilePy - centerY);
+
+      if (tileDist + (PX_PER_TILE * 0.75) < rawDist) {
+        px = Math.round(tilePx);
+        py = Math.round(tilePy);
+      }
+    }
+
+    return { x: px, y: py };
   }
 
   function canMobHitNow({ now, mob, tgtPos, losGrid }) {
@@ -102,9 +138,14 @@
             mi.x, mi.y,
             mm.attack_range,      -- tiles
             mm.aggro_range,       -- tiles
-            mm.attack_ms          -- ms
+            mm.attack_ms,         -- ms
+            s.x  AS spawn_x,
+            s.y  AS spawn_y,
+            COALESCE(s.w, 0) AS spawn_w,
+            COALESCE(s.h, 0) AS spawn_h
         FROM monster_instances mi
         JOIN monsters_master mm ON mm.id = mi.monster_id
+        LEFT JOIN spawns s ON s.id = mi.spawn_id
       WHERE mi.state = 'ALIVE' AND mi.hp > 0
     `)) || [];
   }
@@ -112,9 +153,26 @@
   // 💡 Usa player_online (presença real) + última posição daquele player no mesmo mapa.
   //    **Filtra só heróis VIVOS (hp > 0)** para não mirar em morto.
   async function fetchOnlineHeroesInMap(mapKey) {
-    return await all(`
-      SELECT plp.player_id::text AS player_id,
-            ph.id::text         AS hero_id,
+    const now = Date.now();
+    const merged = [];
+    const seen = new Set();
+
+    const live = listFreshHeroesByMap(mapKey, ONLINE_RECENT_MS) || [];
+    for (const lp of live) {
+      if (!lp?.heroId) continue;
+      const hid = String(lp.heroId);
+      if (seen.has(hid)) continue;
+      merged.push({
+        heroId: hid,
+        x: lp.x | 0,
+        y: lp.y | 0,
+        updatedMs: Number(lp.updatedMs || now),
+      });
+      seen.add(hid);
+    }
+
+    const rows = await all(`
+      SELECT ph.id::text         AS hero_id,
             plp.x|0             AS x,
             plp.y|0             AS y,
             (EXTRACT(EPOCH FROM plp.updated_at) * 1000)::bigint AS updated_ms
@@ -125,7 +183,21 @@
         AND ph.hp > 0
         AND plp.updated_at >= NOW() - ($2 || ' milliseconds')::interval
       ORDER BY plp.updated_at DESC
-    `, [mapKey, String(Math.max(ONLINE_RECENT_MS, 60000))]);
+    `, [mapKey, String(Math.max(ONLINE_RECENT_MS, 60000))]) || [];
+
+    for (const row of rows) {
+      const hid = row?.hero_id ? String(row.hero_id) : null;
+      if (!hid || seen.has(hid)) continue;
+      merged.push({
+        heroId: hid,
+        x: row.x | 0,
+        y: row.y | 0,
+        updatedMs: Number(row.updated_ms || now),
+      });
+      seen.add(hid);
+    }
+
+    return merged;
   }
 
 
@@ -152,6 +224,13 @@
     const id = String(instanceId);
     const cur = mobs.get(id) || {};
 
+    const spawnRect = patch.spawnRect || cur.spawnRect || null;
+    const pos = normalizeMonsterPos({
+      x: patch.x ?? cur.x ?? 0,
+      y: patch.y ?? cur.y ?? 0,
+      spawnRect
+    });
+
     // tiles recebidos do SELECT (fallback para valores anteriores/constantes)
     const attackRangeTiles = Number(patch.attack_range ?? cur.attack_range ?? 1);
     const aggroRangeTiles  = Math.max(1, Number(patch.aggro_range ?? cur.aggro_range ?? 8));
@@ -160,8 +239,8 @@
     const next = {
       instanceId: id,
       mapKey: patch.mapKey ?? cur.mapKey ?? null,
-      x: (patch.x ?? cur.x ?? 0) | 0,
-      y: (patch.y ?? cur.y ?? 0) | 0,
+      x: pos.x | 0,
+      y: pos.y | 0,
 
       // runtime
       posUpdatedAt: Number(patch.posUpdatedAt ?? cur.posUpdatedAt ?? Date.now()),
@@ -183,6 +262,9 @@
       attack_range: attackRangeTiles,
       aggro_range:  aggroRangeTiles,
       attack_ms:    attackMs,
+
+      // debug
+      spawnRect,
     };
 
     mobs.set(id, next);
@@ -190,7 +272,7 @@
   }
 
   // Exposta para seed inicial a partir do index.js
-  function seedPosition({ id, x, y, mapKey }) {
+  function seedPosition({ id, x, y, mapKey, spawnRect }) {
     ensureMob(id, {
       x: (x | 0),
       y: (y | 0),
@@ -198,6 +280,7 @@
       mode: 'idle',
       targetHeroId: null,
       posUpdatedAt: Date.now(),
+      spawnRect,
     });
   }
 
@@ -219,7 +302,18 @@
 
     const alive = await fetchAliveMonsters();
     for (const r of alive) {
-      // DB já em PIXELS -> usar direto
+      const sx = Number(r.spawn_x);
+      const sy = Number(r.spawn_y);
+      const hasSpawn = Number.isFinite(sx) && Number.isFinite(sy);
+      const spawnRect = hasSpawn
+        ? {
+            x: sx,
+            y: sy,
+            w: Number(r.spawn_w),
+            h: Number(r.spawn_h)
+          }
+        : null;
+
       ensureMob(r.id, {
         mapKey: r.map_key,
         x: (r.x | 0),
@@ -228,6 +322,7 @@
         attack_range: r.attack_range,  // ainda em tiles (ok)
         aggro_range:  r.aggro_range,   // ainda em tiles (ok)
         attack_ms:    r.attack_ms,
+        spawnRect,
       });
 
     }
@@ -259,15 +354,7 @@
     }
 
     for (const [mapKey, list] of byMap.entries()) {
-      const heroesRows = await fetchOnlineHeroesInMap(mapKey);
-
-      // x/y em pixels + updated_ms (idade da posição)
-      const heroes = heroesRows.map(r => ({
-        heroId: r.hero_id,
-        x: (r.x | 0),
-        y: (r.y | 0),
-        updatedMs: Number(r.updated_ms || 0),
-      }));
+      const heroes = await fetchOnlineHeroesInMap(mapKey);
 
 
       const { grid, cols } = await getGrid(mapKey);

--- a/server/combat/autoloop.js
+++ b/server/combat/autoloop.js
@@ -38,7 +38,7 @@ async function tickOnce(heroId, targetInstanceId, weaponType) {
   const { grid, cols } = await getGrid(heroPos.map_key);
   const losGrid = { data: grid, cols };
 
-  if (!inReachPx(heroPos, mobPos, weaponType, K)) {
+  if (!inReachPx(heroPos, mobPos, weaponType, K, heroPos.class)) {
     if (DEBUG) console.log('[autoloop] out_of_range');
     return { ok:false, reason:'out_of_range' };
   }

--- a/server/combat/geom.js
+++ b/server/combat/geom.js
@@ -2,6 +2,10 @@
 const TILE = 32;
 const EPS  = 1; // margem mínima anti-oscilação para comparações em PX
 
+const DISTANCE_ALIASES = new Set(['BOW', 'CROSSBOW', 'SPEAR', 'JAVELIN', 'THROWING_KNIFE', 'DISTANCE']);
+const MAGIC_ALIASES = new Set(['MAGIC', 'WAND', 'ROD', 'TOME']);
+const CLASS_RANGE_CAP = { KNIGHT: 1, RANGER: 4, MAGE: 4 };
+
 function toTile(v) {
   return Math.floor(v / TILE);
 }
@@ -18,10 +22,37 @@ function chebyPx(ax, ay, bx, by) {
   return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
 }
 
+function resolveRangeTiles(weaponType, heroClass, K) {
+  const table = (K && K.WEAPON_RANGE_TILES) || {};
+  const rawKey = String(weaponType || '').toUpperCase();
+  const key = rawKey || 'SWORD';
+
+  let rangeTiles = Number(table[key]);
+  if (!Number.isFinite(rangeTiles)) {
+    if (DISTANCE_ALIASES.has(key) && Number.isFinite(table.DISTANCE)) {
+      rangeTiles = Number(table.DISTANCE);
+    } else if (MAGIC_ALIASES.has(key) && Number.isFinite(table.MAGIC)) {
+      rangeTiles = Number(table.MAGIC);
+    }
+  }
+  if (!Number.isFinite(rangeTiles) && Number.isFinite(table.SWORD)) {
+    rangeTiles = Number(table.SWORD);
+  }
+  if (!Number.isFinite(rangeTiles) || rangeTiles <= 0) {
+    rangeTiles = 1;
+  }
+
+  const classKey = String(heroClass || '').toUpperCase();
+  if (classKey && CLASS_RANGE_CAP[classKey]) {
+    rangeTiles = Math.min(rangeTiles, CLASS_RANGE_CAP[classKey]);
+  }
+
+  return Math.max(1, rangeTiles);
+}
+
 /** Alcance por arma comparando em PIXELS (usa tabela em tiles -> px) */
-function inReachPx(attacker, target, weaponType, K) {
-  const key = String(weaponType || 'SWORD').toUpperCase();
-  const rangeTiles = (K.WEAPON_RANGE_TILES && K.WEAPON_RANGE_TILES[key]) ?? 1;
+function inReachPx(attacker, target, weaponType, K, heroClass = null) {
+  const rangeTiles = resolveRangeTiles(weaponType, heroClass, K);
   const rangePx = rangeTiles * TILE;
   const distPx = chebyPx(attacker.x, attacker.y, target.x, target.y);
   return distPx <= (rangePx + EPS);
@@ -34,4 +65,5 @@ module.exports = {
   chebyshevTiles,
   chebyPx,
   inReachPx,
+  resolveRangeTiles,
 };

--- a/server/combat/pos.js
+++ b/server/combat/pos.js
@@ -27,6 +27,7 @@ async function getPlayerLastPos(playerId, mapKey) {
 async function getHeroPos(heroId, preferMapKey = null) {
   const owner = await getHeroOwner(heroId);
   if (!owner) return null;
+  const heroClass = owner.class ? String(owner.class).toUpperCase() : null;
 
   // Se não soubermos o mapa ainda, retorna a última posição global (qualquer mapa)
   if (!preferMapKey) {
@@ -38,13 +39,13 @@ async function getHeroPos(heroId, preferMapKey = null) {
         LIMIT 1`,
       [owner.playerId]
     );
-    if (any) return { x: any.x, y: any.y, map_key: any.mapKey, class: owner.class || null };
+    if (any) return { x: any.x, y: any.y, map_key: any.mapKey, class: heroClass };
     return null;
   }
 
   // Preferimos a posição já no mapa do alvo
   const row = await getPlayerLastPos(owner.playerId, preferMapKey);
-  if (row) return { x: row.x, y: row.y, map_key: row.mapKey, class: owner.class || null };
+  if (row) return { x: row.x, y: row.y, map_key: row.mapKey, class: heroClass };
 
   // Fallback: última posição em qualquer mapa
   const any = await get(
@@ -55,7 +56,7 @@ async function getHeroPos(heroId, preferMapKey = null) {
       LIMIT 1`,
     [owner.playerId]
   );
-  return any ? { x: any.x, y: any.y, map_key: any.mapKey, class: owner.class || null } : null;
+  return any ? { x: any.x, y: any.y, map_key: any.mapKey, class: heroClass } : null;
 }
 
 /** Posição do monstro pela instância */

--- a/server/combat/routes.js
+++ b/server/combat/routes.js
@@ -112,7 +112,7 @@ router.post('/attack/start', express.json(), async (req, res) => {
       const { grid, cols } = await getGrid(heroPos.map_key);
       const losGrid = { data: grid, cols };
 
-      if (!inReachPx(heroPos, mobPos, resolvedWeaponType, K)) return res.json({ ok:false, error:'out_of_range' });
+      if (!inReachPx(heroPos, mobPos, resolvedWeaponType, K, heroPos.class)) return res.json({ ok:false, error:'out_of_range' });
       if (!hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y)) return res.json({ ok:false, error:'no_los' });
     }
 
@@ -196,7 +196,7 @@ router.post('/hit', express.json(), async (req, res) => {
       const losGrid = { data: grid, cols };
 
       // FIX: usar weaponType (antes referenciava var inexistente)
-      if (!inReachPx(heroPos, mobPos, weaponType, K)) return res.json({ ok:false, error:'out_of_range' });
+      if (!inReachPx(heroPos, mobPos, weaponType, K, heroPos.class)) return res.json({ ok:false, error:'out_of_range' });
       if (!hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y)) return res.json({ ok:false, error:'no_los' });
     }
     

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,12 @@ const { endpointMetrics } = require('./middleware/endpoint-metrics');
 const catalogCache = require('./services/catalogCache');
 const idlePoolCloser = require('./services/idlePoolCloser');
 const httpCache = require('./services/httpCache');
+const {
+  setLivePosition,
+  getLivePosition,
+  removeLivePosition,
+  listPlayerIds,
+} = require('./player/live_positions');
 
 const authRoutes = require('./auth/routes');
 const playerRoutes = require('./player/routes'); // mantém seu caminho atual
@@ -64,20 +70,40 @@ const CONTENT_PIPELINE = process.env.CONTENT_PIPELINE || 'off';
 // ---- Autoridade de movimento (Tibia-like) ----
 const TILE = 32;
 const SPEED_CAP_PX_S = 180; // ~0.18 s por tile
-const MIN_STEP_MS = Math.floor((TILE / SPEED_CAP_PX_S) * 1000 * 0.75); // 20% folga
+const STEP_LAG_TOLERANCE_MS = Number(process.env.STEP_LAG_TOLERANCE_MS || 90);
+const STEP_MIN_RATIO = (() => {
+  const raw = Number(process.env.STEP_MIN_RATIO);
+  if (Number.isFinite(raw) && raw > 0 && raw < 1) return raw;
+  return 0.7;
+})();
+const MAX_STEP_PX = Math.hypot(TILE, TILE) + 1; // aceita diagonais como no Tibia
 
-function isAdjacentStep(lx, ly, nx, ny) {
-  const dx = Math.abs(nx - lx), dy = Math.abs(ny - ly);
-  return (dx === TILE && dy === 0) || (dx === 0 && dy === TILE);
+function isStepWithinSpeedCap(lx, ly, nx, ny, dtMs) {
+  const dx = nx - lx;
+  const dy = ny - ly;
+  const dist = Math.hypot(dx, dy);
+
+  if (!Number.isFinite(dist)) return false;
+  if (dist === 0) return true; // mesmo tile (keep-alive)
+  if (dist > MAX_STEP_PX) return false; // teleporte (>1 tile) bloqueado
+
+  const minMsForStep = (dist / SPEED_CAP_PX_S) * 1000;
+  const elapsed = Math.max(0, Number(dtMs) || 0);
+
+  if (elapsed >= minMsForStep) return true;
+
+  const minRatioMs = minMsForStep * STEP_MIN_RATIO;
+  if (elapsed < minRatioMs) return false;
+
+  return (elapsed + STEP_LAG_TOLERANCE_MS) >= minMsForStep;
 }
 
 // ---- [MMO] Posições vivas em RAM + flush periódico p/ DB ----
-const livePositions = new Map(); // playerId -> { x, y, mapKey, ts }
 const FLUSH_POS_INTERVAL_MS = Number(process.env.FLUSH_POS_INTERVAL_MS || 1000);
 let posFlushTimer = null;
 
 async function flushOnePlayerPos(pid) {
-  const p = livePositions.get(String(pid));
+  const p = getLivePosition(pid);
   if (!p) return;
   try {
     await run(`
@@ -98,7 +124,7 @@ async function flushOnePlayerPos(pid) {
 }
 
 async function flushAllPlayerPos() {
-  const ids = Array.from(livePositions.keys());
+  const ids = listPlayerIds();
   for (const pid of ids) {
     await flushOnePlayerPos(pid);
   }
@@ -107,7 +133,7 @@ async function flushAllPlayerPos() {
 function startPosFlusher() {
   if (posFlushTimer) return;
   posFlushTimer = setInterval(async () => {
-    for (const pid of livePositions.keys()) {
+    for (const pid of listPlayerIds()) {
       await flushOnePlayerPos(pid);
     }
   }, FLUSH_POS_INTERVAL_MS);
@@ -1012,6 +1038,8 @@ async function seedAIMobsFromDB(aiMobs) {
         ws.isAlive = true; // compat com heartbeat
         ws._presenceTimer = null;
         ws._pos = null; // cache local da pos autorizada
+        ws._activeHeroId = null;
+        ws._heroAlive = true;
 
         // Tenta validar sessão via cookie JWT
         try {
@@ -1062,9 +1090,28 @@ async function seedAIMobsFromDB(aiMobs) {
                 [ws._player.id, ws._mapKey]
               );
               if (row2 && Number.isFinite(row2.x) && Number.isFinite(row2.y)) {
-                const px = row2.x | 0, py = row2.y | 0;
-                livePositions.set(String(ws._player.id), { x: px, y: py, mapKey: ws._mapKey, ts: Date.now() });
-                ws._pos = { x: px, y: py, mapKey: ws._mapKey, ts: Date.now() };
+                const snapTs = Date.now();
+                const px = row2.x | 0;
+                const py = row2.y | 0;
+                let heroAlive = true;
+                try {
+                  const heroId = await resolveActiveHeroId(ws._player.id);
+                  if (heroId) {
+                    ws._activeHeroId = String(heroId);
+                    const aliveRow = await get(`SELECT alive FROM player_heroes WHERE id=$1`, [heroId]);
+                    heroAlive = !(aliveRow && aliveRow.alive === false);
+                  }
+                } catch {}
+                ws._heroAlive = heroAlive;
+                setLivePosition(ws._player.id, {
+                  x: px,
+                  y: py,
+                  mapKey: ws._mapKey,
+                  heroId: ws._activeHeroId || null,
+                  heroAlive,
+                  ts: snapTs,
+                });
+                ws._pos = { x: px, y: py, mapKey: ws._mapKey, ts: snapTs };
                 try { ws.send(JSON.stringify({ type: 'pos_snap', x: px, y: py, mapKey: ws._mapKey })); } catch {}
               }
             }
@@ -1160,31 +1207,48 @@ async function seedAIMobsFromDB(aiMobs) {
             const pid = ws._player?.id || String(data.id || '');
             if (!pid) return;
 
-            // >>> BLOQUEIO DE MOVIMENTO PARA HERÓI MORTO (server-authoritative)
-            try {
-              const activeHeroId = await resolveActiveHeroId(pid);
-              if (activeHeroId) {
-                const rowAlive = await get(`SELECT alive FROM player_heroes WHERE id=$1`, [activeHeroId]);
-                if (rowAlive && rowAlive.alive === false) {
-                  // opcional: reforça overlay de morte no cliente
-                  try { ws.send(JSON.stringify({ type:'hero_dead', heroId: String(activeHeroId) })); } catch {}
-                  return; // morto não move
-                }
-              }
-            } catch {}
-
             const nx = Number(data.x || 0) | 0;
             const ny = Number(data.y || 0) | 0;
             const mapKey = String(data.mapKey || ws._mapKey || 'house');
 
+            // >>> BLOQUEIO DE MOVIMENTO PARA HERÓI MORTO (server-authoritative)
+            let activeHeroId = null;
+            let heroAlive = true;
+            try {
+              activeHeroId = await resolveActiveHeroId(pid);
+              if (activeHeroId) {
+                ws._activeHeroId = String(activeHeroId);
+                const rowAlive = await get(`SELECT alive FROM player_heroes WHERE id=$1`, [activeHeroId]);
+                heroAlive = !(rowAlive && rowAlive.alive === false);
+                ws._heroAlive = heroAlive;
+                if (!heroAlive) {
+                  setLivePosition(pid, { heroAlive: false, mapKey });
+                  try { ws.send(JSON.stringify({ type:'hero_dead', heroId: String(activeHeroId) })); } catch {}
+                  return; // morto não move
+                }
+              } else if (ws._heroAlive === false) {
+                heroAlive = false;
+              }
+            } catch {
+              if (ws._heroAlive === false) heroAlive = false;
+            }
+
             // Base anterior (RAM ou bootstrap)
             if (!ws._pos || ws._pos.mapKey !== mapKey) {
-              const prev = livePositions.get(String(pid));
+              const prev = getLivePosition(pid);
               if (prev && prev.mapKey === mapKey) {
-                ws._pos = { ...prev };
+                ws._pos = { x: prev.x | 0, y: prev.y | 0, mapKey: prev.mapKey, ts: prev.ts || Date.now() };
               } else {
-                ws._pos = { x: nx, y: ny, mapKey, ts: Date.now() };
-                livePositions.set(String(pid), { ...ws._pos });
+                const baseTs = Date.now();
+                ws._pos = { x: nx, y: ny, mapKey, ts: baseTs };
+                setLivePosition(pid, {
+                  x: nx,
+                  y: ny,
+                  mapKey,
+                  heroId: ws._activeHeroId || activeHeroId || null,
+                  heroAlive: heroAlive !== false,
+                  ts: baseTs,
+                });
               }
             }
 
@@ -1192,22 +1256,25 @@ async function seedAIMobsFromDB(aiMobs) {
             const now = Date.now();
             const dt = now - (lts || 0);
 
-            // helpers
             const sameTile = (a, b) => Math.floor(a / TILE) === Math.floor(b / TILE);
-            const okAdj = isAdjacentStep(lx, ly, nx, ny);
-            const okTime = dt >= MIN_STEP_MS;
+            const allowSameTile = sameTile(lx, nx) && sameTile(ly, ny); // keep-alive/quantização
+            const okSpeed = isStepWithinSpeedCap(lx, ly, nx, ny, dt);
 
-            // --- NOVO: se o último ponto não estava quantizado, aceite o 1º passo dentro do MESMO tile
-            const tolerateSameTileFirstStep = (!okAdj && sameTile(lx, nx) && sameTile(ly, ny));
-
-            if (!(okAdj && okTime) && !tolerateSameTileFirstStep) {
+            if (!okSpeed && !allowSameTile) {
               try { ws.send(JSON.stringify({ type: 'pos_snap', x: lx, y: ly, mapKey })); } catch {}
               return;
             }
 
             // Autoriza: atualiza RAM
             ws._pos = { x: nx, y: ny, mapKey, ts: now };
-            livePositions.set(String(pid), { x: nx, y: ny, mapKey, ts: now });
+            setLivePosition(pid, {
+              x: nx,
+              y: ny,
+              mapKey,
+              heroId: ws._activeHeroId || activeHeroId || null,
+              heroAlive: heroAlive !== false,
+              ts: now,
+            });
             ws._mapKey = mapKey;
 
             // presença online
@@ -1247,7 +1314,7 @@ async function seedAIMobsFromDB(aiMobs) {
           if (ws._player?.id) {
             // flush posição no logout + remove presença
             flushOnePlayerPos(ws._player.id).catch(() => {});
-            livePositions.delete(String(ws._player.id));
+            removeLivePosition(ws._player.id);
             markOfflineByPlayer(ws._player.id).catch(() => {});
           }
         });

--- a/server/player/live_positions.js
+++ b/server/player/live_positions.js
@@ -1,0 +1,89 @@
+// server/player/live_positions.js
+// In-memory authority of player positions shared between WS and combat AI.
+
+const livePositions = new Map(); // playerId -> { x, y, mapKey, heroId, heroAlive, ts }
+
+function sanitizeInt(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? (n | 0) : (fallback | 0);
+}
+
+function sanitizeTs(ts) {
+  const n = Number(ts);
+  return Number.isFinite(n) && n > 0 ? n : Date.now();
+}
+
+function sanitizeMapKey(mapKey, fallback = 'house') {
+  const key = String(mapKey || '').trim();
+  return key ? key : String(fallback || 'house');
+}
+
+function setLivePosition(playerId, pos = {}) {
+  const pid = String(playerId || '').trim();
+  if (!pid) return null;
+
+  const prev = livePositions.get(pid) || {};
+  const ts = sanitizeTs(pos.ts ?? prev.ts ?? Date.now());
+  const mapKey = sanitizeMapKey(pos.mapKey ?? prev.mapKey ?? 'house');
+  const heroId = pos.heroId != null ? String(pos.heroId) : (prev.heroId != null ? String(prev.heroId) : null);
+  const heroAlive = pos.heroAlive === false ? false : (pos.heroAlive === true ? true : (prev.heroAlive === false ? false : true));
+
+  const next = {
+    x: sanitizeInt(pos.x ?? prev.x ?? 0),
+    y: sanitizeInt(pos.y ?? prev.y ?? 0),
+    mapKey,
+    heroId,
+    heroAlive,
+    ts,
+  };
+
+  livePositions.set(pid, next);
+  return next;
+}
+
+function getLivePosition(playerId) {
+  const pid = String(playerId || '').trim();
+  if (!pid) return null;
+  return livePositions.get(pid) || null;
+}
+
+function removeLivePosition(playerId) {
+  const pid = String(playerId || '').trim();
+  if (!pid) return;
+  livePositions.delete(pid);
+}
+
+function listPlayerIds() {
+  return Array.from(livePositions.keys());
+}
+
+function listFreshHeroesByMap(mapKey, maxAgeMs = 1000) {
+  const now = Date.now();
+  const key = sanitizeMapKey(mapKey);
+  const maxAge = Number(maxAgeMs);
+
+  const fresh = [];
+  for (const [pid, pos] of livePositions.entries()) {
+    if (!pos) continue;
+    if (pos.mapKey !== key) continue;
+    if (pos.heroAlive === false) continue;
+    const age = now - (pos.ts || 0);
+    if (Number.isFinite(maxAge) && maxAge >= 0 && age > maxAge) continue;
+    fresh.push({
+      playerId: pid,
+      heroId: pos.heroId || null,
+      x: pos.x | 0,
+      y: pos.y | 0,
+      updatedMs: pos.ts || 0,
+    });
+  }
+  return fresh;
+}
+
+module.exports = {
+  setLivePosition,
+  getLivePosition,
+  removeLivePosition,
+  listPlayerIds,
+  listFreshHeroesByMap,
+};

--- a/server/respawn/worker.js
+++ b/server/respawn/worker.js
@@ -74,6 +74,9 @@ async function respawnTick({ all, run }) {
     // Escolhe uma posição dentro da área do spawn (em pixels)
     const pos = pickPosInSpawnRect(r);
 
+    const px = Math.round(pos.x);
+    const py = Math.round(pos.y);
+
     await run(
       `UPDATE monster_instances
           SET state            = 'ALIVE',
@@ -81,10 +84,25 @@ async function respawnTick({ all, run }) {
               respawn_at       = NULL,
               last_hit_hero_id = NULL,
               last_hit_at      = NULL,
+              x                = $3,
+              y                = $4,
               updated_at       = now()
         WHERE id = $1`,
-      [r.id, hpFull]
+      [r.id, hpFull, px, py]
     );
+
+    try {
+      const aiMobs = require('../combat/ai-mobs');
+      if (aiMobs && typeof aiMobs.seedPosition === 'function') {
+        aiMobs.seedPosition({
+          id: r.id,
+          x: px,
+          y: py,
+          mapKey: r.map_key,
+          spawnRect: { x: r.x, y: r.y, w: r.w, h: r.h }
+        });
+      }
+    } catch {}
 
     // Notifica frontend que a instância renasceu, COM x,y em pixels
     try {


### PR DESCRIPTION
## Summary
- expose an in-memory live position store and hook the WebSocket movement pipeline so hero id/alive state are tracked in real time
- have the monster AI read the shared live positions before falling back to the database, extending the freshness window so mobs can chase and swing accurately
- clamp weapon range to vocation-specific caps and pass hero class data through server validations to block off-tile hits for bows and spells

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6ac4aa65c8327bc4a83ff7485986e