### PR TITLE
Improve combat range validation and messaging

### DIFF
--- a/client/js/combat/attack-controls.js
+++ b/client/js/combat/attack-controls.js
@@ -1,6 +1,7 @@
 //client/js/combat/attack-controls.js
 import { apiGet, apiPost, getCsrf } from '../api.js';
 import { HeroState } from '../state/hero-state.js';
+import { showCombatMessage, hideCombatMessage } from '../ui/combat-message.js';
 
 
 const combatState = (window.combatState = window.combatState || {
@@ -9,6 +10,8 @@ const combatState = (window.combatState = window.combatState || {
   attacking: false,
   loopHandle: null,
   selectedTargetId: null,
+  lastWarningCode: null,
+  lastWarningAt: 0,
 });
 
 // Check environment flag for RMB attack mode
@@ -95,6 +98,80 @@ async function ensureActiveHero() {
 }
 
 
+function emitCombatWarning(code, message) {
+  if (!message) return;
+  const now = Date.now();
+  if (combatState.lastWarningCode === code && now - (combatState.lastWarningAt || 0) < 700) {
+    return;
+  }
+  combatState.lastWarningCode = code;
+  combatState.lastWarningAt = now;
+  showCombatMessage(message);
+}
+
+function clearCombatWarnings() {
+  combatState.lastWarningCode = null;
+  combatState.lastWarningAt = 0;
+  hideCombatMessage();
+}
+
+function resolveWarningFromPayload(payload) {
+  if (!payload) return null;
+  if (Array.isArray(payload.warnings) && payload.warnings.length) {
+    const first = payload.warnings.find(w => w && (w.message || w.code)) || payload.warnings[0];
+    if (first) {
+      return {
+        code: String(first.code || payload.error || 'warn'),
+        message: first.message || payload.message || null,
+      };
+    }
+  }
+  const code = payload.error ? String(payload.error) : null;
+  const message = payload.message || null;
+  if (!code && !message) return null;
+  return { code: code || 'warn', message };
+}
+
+function friendlyMessage(code, fallback) {
+  const c = String(code || '').toLowerCase();
+  if (c === 'out_of_range' || c === 'out-of-range') return fallback || 'Você está longe do alvo.';
+  if (c === 'no_los' || c === 'no-los') return fallback || 'Sem linha de visão com o alvo.';
+  if (c === 'no-weapon-equipped') return fallback || 'Equipe uma arma para atacar.';
+  if (c === 'map-diff') return fallback || 'Alvo está em outro local.';
+  if (c === 'hero-dead') return fallback || 'Seu herói está morto.';
+  return fallback || null;
+}
+
+function handleCombatWarning(payload, opts = {}) {
+  const info = resolveWarningFromPayload(payload);
+  if (!info) return false;
+
+  const code = info.code || 'warn';
+  const message = friendlyMessage(code, info.message);
+
+  const lower = String(code).toLowerCase();
+  if (lower === 'map-diff' || lower === 'no-weapon-equipped' || lower === 'hero-not-found' || lower === 'hero-dead') {
+    emitCombatWarning(code, message || 'Ação não permitida.');
+    stopAttack({ keepWarnings: true });
+    return true;
+  }
+
+  if (lower === 'out_of_range' || lower === 'out-of-range' || lower === 'no_los' || lower === 'no-los') {
+    emitCombatWarning(code, message || 'Ação não permitida.');
+    return true;
+  }
+
+  if (opts.stopOnFail) {
+    emitCombatWarning(code, message || 'Ação não permitida.');
+    stopAttack({ keepWarnings: true });
+    return true;
+  }
+
+  if (message) emitCombatWarning(code, message);
+  return true;
+}
+
+
 /** resolve alvo no servidor; retorna { id, x, y, hp, maxHp } ou null */
 async function resolveServerTarget(pxClick, pyClick) {
   const map = window.GameScene?.mapKey || 'house';
@@ -164,6 +241,13 @@ async function doHit() {
       damage: 10
     });
 
+    if (!resp?.ok) {
+      if (handleCombatWarning(resp)) return;
+      return;
+    }
+
+    clearCombatWarnings();
+
     const id     = String(resp.id || resp.targetId || combatState.targetId);
     const hpNow  = Number(resp.hpAfter ?? resp.hp);
     const hpPrev = Number(resp.hpBefore ?? (isFinite(hpNow) ? hpNow + Number(resp.dmg || 0) : 0));
@@ -206,7 +290,19 @@ export async function startAttack(targetId) {
 
   try {
     const resp = await apiPost('/api/combat/attack/start', payload);
-    if (!resp?.ok) { console.warn('[attack] start recusado:', resp?.error || 'start-rejected'); return; }
+    if (!resp?.ok) {
+      if (handleCombatWarning(resp, { stopOnFail: true })) return;
+      console.warn('[attack] start recusado:', resp?.error || 'start-rejected');
+      return;
+    }
+
+    if (Array.isArray(resp.warnings) && resp.warnings.length) {
+      handleCombatWarning(resp);
+    } else if (resp?.message) {
+      handleCombatWarning({ error: 'info', message: resp.message });
+    } else {
+      clearCombatWarnings();
+    }
   } catch (err) { console.warn('[attack] start falhou:', err?.message || err); return; }
 
   combatState.targetId = String(targetId);
@@ -216,11 +312,13 @@ export async function startAttack(targetId) {
   window.dispatchEvent(new CustomEvent('combat:attack:start', { detail:{ targetId: combatState.targetId } }));
 }
 
-export async function stopAttack() {
+export async function stopAttack(options = {}) {
+  const opts = (options && typeof options === 'object') ? options : {};
   const hero = await ensureActiveHero();
   combatState.attacking = false;
   combatState.targetId = null;
   window.combatState.selectedTargetId = null;
+  if (!opts.keepWarnings) clearCombatWarnings();
   if (combatState.loopHandle) { clearInterval(combatState.loopHandle); combatState.loopHandle = null; }
   try { await apiPost('/api/combat/attack/stop', { heroId: hero?.id || null }); } catch {}
   window.dispatchEvent(new CustomEvent('combat:attack:stop'));

--- a/client/js/ui/combat-message.js
+++ b/client/js/ui/combat-message.js
@@ -1,0 +1,59 @@
+// client/js/ui/combat-message.js
+// Simple floating message overlay for combat feedback (range/LOS warnings)
+
+const CONTAINER_ID = 'combat-message-overlay';
+const HIDE_DELAY_MS = 1600;
+let hideTimer = null;
+
+function ensureContainer() {
+  let el = document.getElementById(CONTAINER_ID);
+  if (el) return el;
+
+  el = document.createElement('div');
+  el.id = CONTAINER_ID;
+  Object.assign(el.style, {
+    position: 'absolute',
+    top: '15%',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    padding: '6px 12px',
+    borderRadius: '6px',
+    background: 'rgba(0, 0, 0, 0.65)',
+    color: '#fff',
+    fontFamily: 'var(--hud-font, "Trebuchet MS", sans-serif)',
+    fontSize: '15px',
+    letterSpacing: '0.5px',
+    textShadow: '0 0 4px rgba(0,0,0,0.8)',
+    pointerEvents: 'none',
+    opacity: '0',
+    transition: 'opacity 160ms ease-in-out',
+    zIndex: '9999',
+    whiteSpace: 'nowrap',
+  });
+
+  document.body.appendChild(el);
+  return el;
+}
+
+export function showCombatMessage(message) {
+  if (!message) return;
+  const el = ensureContainer();
+  el.textContent = String(message);
+  el.style.opacity = '1';
+
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = setTimeout(() => {
+    el.style.opacity = '0';
+  }, HIDE_DELAY_MS);
+}
+
+export function hideCombatMessage() {
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  const el = document.getElementById(CONTAINER_ID);
+  if (el) {
+    el.style.opacity = '0';
+  }
+}

--- a/server/combat/geom.js
+++ b/server/combat/geom.js
@@ -2,6 +2,10 @@
 const TILE = 32;
 const EPS  = 1; // margem mínima anti-oscilação para comparações em PX
 
+const DISTANCE_ALIASES = new Set(['BOW', 'CROSSBOW', 'SPEAR', 'JAVELIN', 'THROWING_KNIFE', 'DISTANCE']);
+const MAGIC_ALIASES = new Set(['MAGIC', 'WAND', 'ROD', 'TOME', 'STAFF']);
+const CLASS_RANGE_CAP = { KNIGHT: 1, RANGER: 4, MAGE: 4 };
+
 function toTile(v) {
   return Math.floor(v / TILE);
 }
@@ -18,10 +22,39 @@ function chebyPx(ax, ay, bx, by) {
   return Math.max(Math.abs(ax - bx), Math.abs(ay - by));
 }
 
+function resolveRangeTiles(weaponType, heroClass, K) {
+  const table = (K && K.WEAPON_RANGE_TILES) || {};
+  const rawKey = String(weaponType || '').toUpperCase();
+  const key = rawKey || 'SWORD';
+
+  let rangeTiles = Number(table[key]);
+  if (!Number.isFinite(rangeTiles)) {
+    if (DISTANCE_ALIASES.has(key) && Number.isFinite(table.DISTANCE)) {
+      rangeTiles = Number(table.DISTANCE);
+    } else if (MAGIC_ALIASES.has(key) && Number.isFinite(table.MAGIC)) {
+      rangeTiles = Number(table.MAGIC);
+    }
+  }
+
+  if (!Number.isFinite(rangeTiles) && Number.isFinite(table.SWORD)) {
+    rangeTiles = Number(table.SWORD);
+  }
+
+  if (!Number.isFinite(rangeTiles) || rangeTiles <= 0) {
+    rangeTiles = 1;
+  }
+
+  const classKey = String(heroClass || '').toUpperCase();
+  if (classKey && CLASS_RANGE_CAP[classKey]) {
+    rangeTiles = Math.min(rangeTiles, CLASS_RANGE_CAP[classKey]);
+  }
+
+  return Math.max(1, rangeTiles);
+}
+
 /** Alcance por arma comparando em PIXELS (usa tabela em tiles -> px) */
-function inReachPx(attacker, target, weaponType, K) {
-  const key = String(weaponType || 'SWORD').toUpperCase();
-  const rangeTiles = (K.WEAPON_RANGE_TILES && K.WEAPON_RANGE_TILES[key]) ?? 1;
+function inReachPx(attacker, target, weaponType, K, heroClass = null) {
+  const rangeTiles = resolveRangeTiles(weaponType, heroClass, K);
   const rangePx = rangeTiles * TILE;
   const distPx = chebyPx(attacker.x, attacker.y, target.x, target.y);
   return distPx <= (rangePx + EPS);
@@ -34,4 +67,5 @@ module.exports = {
   chebyshevTiles,
   chebyPx,
   inReachPx,
+  resolveRangeTiles,
 };

--- a/server/combat/routes.js
+++ b/server/combat/routes.js
@@ -10,15 +10,12 @@ const K = require('../balance/config');
 
 const { get, run } = require('../models/db');
 const { getHeroPos, getMonsterPos } = require('./pos');
-const { inReachPx } = require('./geom');
+const { inReachPx, resolveRangeTiles, chebyPx, chebyshevTiles, TILE } = require('./geom');
 const { hasLineOfSight } = require('./los');
 const { getGrid } = require('../maps/grid');
 
 // >>> loot service (em memória)
 const { createLootFromKill } = require('../services/loot');
-
-// Strict por padrão: revalida alcance/LOS a cada hit quando ATTACK_STRICT_MODE=1
-const PERMISSIVE_START = !Boolean(K.ATTACK_STRICT_MODE);
 
 
 const DEBUG = String(process.env.COMBAT_DEBUG || '').trim() === '1';
@@ -29,6 +26,61 @@ const attackSessions = new Map();
 
 // quanto cada hit vale (em "tries"), antes de multiplicar pelos rates de classe
 const BASE_TRY_PER_HIT = Number(process.env.SKILL_TRY_PER_HIT || 1);
+
+function buildRangeTelemetry(heroPos, mobPos, weaponType) {
+  if (!heroPos || !mobPos || !weaponType) return null;
+  const rangeTiles = resolveRangeTiles(weaponType, heroPos.class, K);
+  const rangePx = rangeTiles * TILE;
+  const distTiles = chebyshevTiles(heroPos.x, heroPos.y, mobPos.x, mobPos.y);
+  const distPx = chebyPx(heroPos.x, heroPos.y, mobPos.x, mobPos.y);
+  return {
+    range: { tiles: rangeTiles, px: rangePx },
+    distance: { tiles: distTiles, px: distPx },
+  };
+}
+
+function formatRangeMessage(ctx) {
+  if (!ctx) return 'Você está longe do alvo.';
+  const distTiles = Number(ctx?.distance?.tiles);
+  const rangeTiles = Number(ctx?.range?.tiles);
+  if (Number.isFinite(distTiles) && Number.isFinite(rangeTiles)) {
+    return `Você está longe do alvo (${distTiles} > ${rangeTiles} sqm).`;
+  }
+  const distPx = Number(ctx?.distance?.px);
+  const rangePx = Number(ctx?.range?.px);
+  if (Number.isFinite(distPx) && Number.isFinite(rangePx)) {
+    return `Você está longe do alvo (${Math.round(distPx)} > ${Math.round(rangePx)} px).`;
+  }
+  return 'Você está longe do alvo.';
+}
+
+function buildOutOfRangePayload(ctx) {
+  const message = formatRangeMessage(ctx);
+  return {
+    ok: false,
+    error: 'out_of_range',
+    inRange: false,
+    hasLineOfSight: ctx?.hasLineOfSight ?? true,
+    range: ctx?.range || null,
+    distance: ctx?.distance || null,
+    message,
+    warnings: [{ code: 'out_of_range', message }],
+  };
+}
+
+function buildNoLoSPayload(ctx) {
+  const message = 'Sem linha de visão com o alvo.';
+  return {
+    ok: false,
+    error: 'no_los',
+    inRange: ctx?.inRange ?? null,
+    hasLineOfSight: false,
+    range: ctx?.range || null,
+    distance: ctx?.distance || null,
+    message,
+    warnings: [{ code: 'no_los', message }],
+  };
+}
 
 router.use((req, _res, next) => {
   if (DEBUG) console.log(`[combat] ${req.method} ${req.originalUrl}`);
@@ -101,20 +153,24 @@ router.post('/attack/start', express.json(), async (req, res) => {
       return res.json({ ok: false, error: 'no-weapon-equipped' });
     }
 
-    if (!PERMISSIVE_START) {
-      const mobPos = await getMonsterPos(targetInstanceId);
-      if (!mobPos) return res.status(400).json({ ok:false, error:'mob-pos-missing' });
+    const mobPos = await getMonsterPos(targetInstanceId);
+    if (!mobPos) return res.status(400).json({ ok:false, error:'mob-pos-missing' });
 
-      const heroPos = await getHeroPos(heroId, mobPos.map_key);
-      if (!heroPos) return res.status(400).json({ ok:false, error:'hero-pos-missing' });
-      if (heroPos.map_key !== mobPos.map_key) return res.json({ ok:false, error:'map-diff' });
-
-      const { grid, cols } = await getGrid(heroPos.map_key);
-      const losGrid = { data: grid, cols };
-
-      if (!inReachPx(heroPos, mobPos, resolvedWeaponType, K)) return res.json({ ok:false, error:'out_of_range' });
-      if (!hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y)) return res.json({ ok:false, error:'no_los' });
+    const heroPos = await getHeroPos(heroId, mobPos.map_key);
+    if (!heroPos) return res.status(400).json({ ok:false, error:'hero-pos-missing' });
+    if (heroPos.map_key !== mobPos.map_key) {
+      return res.json({ ok:false, error:'map-diff', message:'Alvo está em outro mapa.' });
     }
+
+    const { grid, cols } = await getGrid(heroPos.map_key);
+    const losGrid = { data: grid, cols };
+
+    const inRange = inReachPx(heroPos, mobPos, resolvedWeaponType, K, heroPos.class);
+    const hasLos = hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y);
+    const telemetry = buildRangeTelemetry(heroPos, mobPos, resolvedWeaponType);
+    const warnings = [];
+    if (!inRange) warnings.push({ code:'out_of_range', message: formatRangeMessage({ ...telemetry, inRange }) });
+    if (!hasLos) warnings.push({ code:'no_los', message: 'Sem linha de visão com o alvo.' });
 
     attackSessions.set(String(targetInstanceId), {
       heroId: String(heroId),
@@ -122,7 +178,17 @@ router.post('/attack/start', express.json(), async (req, res) => {
       startedAt: Date.now()
     });
 
-    return res.json({ ok:true });
+    const payload = {
+      ok: true,
+      inRange,
+      hasLineOfSight: hasLos,
+      range: telemetry?.range || null,
+      distance: telemetry?.distance || null,
+      warnings,
+    };
+    if (warnings.length) payload.message = warnings[0].message;
+
+    return res.json(payload);
   } catch (e) {
     console.error('[combat] /attack/start error:', e);
     return res.status(500).json({ ok:false, error:'start-failed' });
@@ -183,27 +249,28 @@ router.post('/hit', express.json(), async (req, res) => {
       return res.json({ ok: false, error: 'no-weapon-equipped' });
     }
 
-    // Validate range/LOS first if not permissive
-    if (!PERMISSIVE_START) {
-      const mobPos = await getMonsterPos(raw);
-      if (!mobPos) return res.status(400).json({ ok:false, error:'mob-pos-missing' });
+    const mobPos = await getMonsterPos(raw);
+    if (!mobPos) return res.status(400).json({ ok:false, error:'mob-pos-missing' });
 
-      const heroPos = await getHeroPos(heroIdFromSess, mobPos.map_key);
-      if (!heroPos) return res.status(400).json({ ok:false, error:'hero-pos-missing' });
-      if (heroPos.map_key !== mobPos.map_key) return res.json({ ok:false, error:'map-diff' });
+    const heroPos = await getHeroPos(heroIdFromSess, mobPos.map_key);
+    if (!heroPos) return res.status(400).json({ ok:false, error:'hero-pos-missing' });
+    if (heroPos.map_key !== mobPos.map_key) return res.json({ ok:false, error:'map-diff', message:'Alvo está em outro mapa.' });
 
-      const { grid, cols } = await getGrid(heroPos.map_key);
-      const losGrid = { data: grid, cols };
+    const { grid, cols } = await getGrid(heroPos.map_key);
+    const losGrid = { data: grid, cols };
 
-      // FIX: usar weaponType (antes referenciava var inexistente)
-      if (!inReachPx(heroPos, mobPos, weaponType, K)) return res.json({ ok:false, error:'out_of_range' });
-      if (!hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y)) return res.json({ ok:false, error:'no_los' });
-    }
-    
+    const inRange = inReachPx(heroPos, mobPos, weaponType, K, heroPos.class);
+    const hasLos = hasLineOfSight(losGrid, heroPos.x, heroPos.y, mobPos.x, mobPos.y);
+    const telemetry = buildRangeTelemetry(heroPos, mobPos, weaponType);
+    const context = telemetry ? { ...telemetry, inRange, hasLineOfSight: hasLos } : { inRange, hasLineOfSight: hasLos };
+
+    if (!inRange) return res.json(buildOutOfRangePayload(context));
+    if (!hasLos) return res.json(buildNoLoSPayload(context));
+
     // Call the service to apply hit
-    const result = await applyHit({ 
-      attackerHeroId: heroIdFromSess, 
-      targetInstanceId: String(raw), 
+    const result = await applyHit({
+      attackerHeroId: heroIdFromSess,
+      targetInstanceId: String(raw),
       weaponType 
     });
 
@@ -233,6 +300,13 @@ router.post('/hit', express.json(), async (req, res) => {
       hpBefore: result.hpAfter + result.damage, // aproximação
       dead: result.dead
     };
+
+    if (telemetry) {
+      payload.range = telemetry.range;
+      payload.distance = telemetry.distance;
+      payload.inRange = true;
+      payload.hasLineOfSight = true;
+    }
 
     return res.json(payload);
   } catch (e) {


### PR DESCRIPTION
## Summary
- add a lightweight combat message overlay and throttle logic so range and line-of-sight warnings appear without spamming the player while keeping the target selected
- return structured range telemetry from combat endpoints, allowing attack/start to succeed with warnings and preventing out-of-range hits server-side
- enforce vocation-specific reach caps in the geom helpers to keep melee and distance classes within their intended attack distances

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6ac4aa65c8327bc4a83ff7485986e