### PR TITLE
Convert player_last_pos player_id to text

### DIFF
--- a/server/db/migrations/2024_11_29_player_last_pos_player_id_text.sql
+++ b/server/db/migrations/2024_11_29_player_last_pos_player_id_text.sql
@@ -1,0 +1,15 @@
+-- Migration: change player_last_pos.player_id to TEXT to support UUID identifiers
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM information_schema.columns
+     WHERE table_name = 'player_last_pos'
+       AND column_name = 'player_id'
+       AND data_type <> 'text'
+  ) THEN
+    ALTER TABLE player_last_pos
+      ALTER COLUMN player_id TYPE TEXT USING player_id::text;
+  END IF;
+END$$;

--- a/server/index.js
+++ b/server/index.js
@@ -313,8 +313,8 @@ async function bootstrapContentTables() {
     // posição do player por mapa
     await run(`
       CREATE TABLE IF NOT EXISTS player_last_pos (
-        player_id BIGINT NOT NULL,
-        map_key   TEXT   NOT NULL,
+        player_id TEXT NOT NULL,
+        map_key   TEXT NOT NULL,
         x INTEGER NOT NULL,
         y INTEGER NOT NULL,
         last_seq BIGINT DEFAULT 0,


### PR DESCRIPTION
## Summary
- add a SQL migration that converts player_last_pos.player_id to TEXT when needed
- update the bootstrap DDL so new installs create player_last_pos with a TEXT player_id column

## Testing
- PGSSLMODE=disable DATABASE_URL=postgresql://postgres:postgres@localhost:5432/afk npm run pg:migrate
- sudo -u postgres psql -d afk -f server/db/migrations/2024_11_29_player_last_pos_player_id_text.sql
- sudo -u postgres psql -d afk -c "\\d player_last_pos"


------
https://chatgpt.com/codex/tasks/task_e_68d759987cb08327bf3c0db4b2d4b999