### PR TITLE
Preserve stale live positions for combat range

### DIFF
--- a/server/combat/pos.js
+++ b/server/combat/pos.js
@@ -2,8 +2,6 @@
 const { get } = require('../models/db');
 const { getLivePlayerPosition } = require('../player/live_positions');
 
-const TILE = 32;
-
 async function getHeroOwner(heroId) {
   return await get(
     `SELECT ph.id AS "heroId", ph."playerId" AS "playerId", hm.class AS class
@@ -34,45 +32,40 @@ async function getHeroPos(heroId, preferMapKey = null) {
   const classKey = owner.class || null;
 
   // 1) Live primeiro
-  const live = getLivePlayerPosition(owner.playerId);
+  const live = getLivePlayerPosition(owner.playerId, { allowStale: true });
+  let fallbackPos = null;
   if (live) {
     const liveMapKey = String(live.mapKey || preferMapKey || 'house');
 
-    let px = Number(live.x || 0);
-    let py = Number(live.y || 0);
-    if (px < 1000 && py < 1000) {
-      px = (px * TILE) + (TILE / 2);
-      py = (py * TILE) + (TILE / 2);
-    }
-
     const livePos = {
-      x: px | 0,
-      y: py | 0,
+      x: Math.round(Number(live.x || 0)),
+      y: Math.round(Number(live.y || 0)),
       map_key: liveMapKey,
       class: classKey,
-      source: 'live',
+      source: live.stale ? 'live_stale' : 'live',
+      stale: Boolean(live.stale),
       updatedAt: Number(live.ts || Date.now()),
     };
 
+    if (Number.isFinite(live.age)) {
+      livePos.ageMs = Number(live.age);
+    }
+
     if (!preferMapKey || liveMapKey === preferMapKey) return livePos;
+    fallbackPos = livePos;
   }
 
   // 2) DB no mapa preferido
   if (preferMapKey) {
     const row = await getPlayerLastPos(owner.playerId, preferMapKey);
     if (row) {
-      let px = Number(row.x || 0);
-      let py = Number(row.y || 0);
-      if (px < 1000 && py < 1000) {
-        px = (px * TILE) + (TILE / 2);
-        py = (py * TILE) + (TILE / 2);
-      }
       return {
-        x: px | 0,
-        y: py | 0,
+        x: Math.round(Number(row.x || 0)),
+        y: Math.round(Number(row.y || 0)),
         map_key: row.mapKey,
         class: classKey,
         source: 'db',
+        stale: false,
         updatedAt: row.updatedAt ? new Date(row.updatedAt).getTime() : null,
       };
     }
@@ -89,23 +82,18 @@ async function getHeroPos(heroId, preferMapKey = null) {
   );
 
   if (any) {
-    let px = Number(any.x || 0);
-    let py = Number(any.y || 0);
-    if (px < 1000 && py < 1000) {
-      px = (px * TILE) + (TILE / 2);
-      py = (py * TILE) + (TILE / 2);
-    }
     return {
-      x: px | 0,
-      y: py | 0,
+      x: Math.round(Number(any.x || 0)),
+      y: Math.round(Number(any.y || 0)),
       map_key: any.mapKey,
       class: classKey,
       source: 'db',
+      stale: false,
       updatedAt: any.updatedAt ? new Date(any.updatedAt).getTime() : null,
     };
   }
 
-  return null;
+  return fallbackPos;
 }
 
 /**
@@ -135,13 +123,9 @@ async function getMonsterPos(instanceId) {
 
   if (!row) return null;
 
-  let px = Number(row.x || 0);
-  let py = Number(row.y || 0);
-  if (px < 1000 && py < 1000) { px = (px * TILE) + (TILE / 2); py = (py * TILE) + (TILE / 2); }
-
   return {
-    x: px | 0,
-    y: py | 0,
+    x: Math.round(Number(row.x || 0)),
+    y: Math.round(Number(row.y || 0)),
     map_key: row.map_key,
     frame_w: Number(row.frame_w || 32),
     frame_h: Number(row.frame_h || 32),

--- a/server/combat/routes.js
+++ b/server/combat/routes.js
@@ -56,6 +56,8 @@ function buildRangeTelemetry(heroPos, mobPos, weaponType) {
       mapKey: heroPos.map_key || heroPos.mapKey || null,
       updatedAt: Number(heroPos.updatedAt || 0) || null,
       source: heroPos.source || null,
+      stale: heroPos.stale === true,
+      ageMs: Number.isFinite(heroPos.ageMs) ? Number(heroPos.ageMs) : null,
     },
     monster: {
       x: mx,

--- a/server/player/live_positions.js
+++ b/server/player/live_positions.js
@@ -4,7 +4,11 @@
 // TTL configurável por env: LIVE_POS_TTL_MS (default 1500ms)
 
 const TTL_MS = Math.max(300, Number(process.env.LIVE_POS_TTL_MS || 1500));
-const GC_MS  = Math.max(TTL_MS, Number(process.env.LIVE_POS_GC_MS  || 5000));
+const STALE_MS = Math.max(
+  TTL_MS,
+  Number(process.env.LIVE_POS_STALE_MS || (TTL_MS * 6))
+);
+const GC_MS  = Math.max(STALE_MS, Number(process.env.LIVE_POS_GC_MS  || STALE_MS));
 
 /** store: playerId -> { x, y, mapKey, heroId, heroAlive, ts } */
 const store = new Map();
@@ -51,16 +55,38 @@ function setLivePlayerPosition(playerId, xOrObj, y, mapKey, heroId, heroAlive, t
   return next;
 }
 
-function getLivePlayerPosition(playerId) {
+function getLivePlayerPosition(playerId, opts = {}) {
   const id = String(playerId || '').trim();
   if (!id) return null;
   const pos = store.get(id);
   if (!pos) return null;
-  if (Date.now() - (pos.ts || 0) > TTL_MS) {
+  const now = Date.now();
+  const age = now - (pos.ts || 0);
+  if (age > STALE_MS) {
     store.delete(id);
     return null;
   }
-  return pos;
+
+  const allowStale = Boolean(opts && opts.allowStale);
+  if (!allowStale && age > TTL_MS) {
+    return null;
+  }
+
+  const out = {
+    x: pos.x | 0,
+    y: pos.y | 0,
+    mapKey: pos.mapKey,
+    heroId: pos.heroId != null ? String(pos.heroId) : null,
+    heroAlive: pos.heroAlive === false ? false : true,
+    ts: pos.ts,
+  };
+
+  if (allowStale) {
+    out.stale = age > TTL_MS;
+    out.age = age;
+  }
+
+  return out;
 }
 
 function clearLivePlayerPosition(playerId) {
@@ -105,7 +131,7 @@ function markHeroAlive(playerId, alive, heroId = null) {
 setInterval(() => {
   const now = Date.now();
   for (const [id, pos] of store.entries()) {
-    if (!pos || now - (pos.ts || 0) > TTL_MS) store.delete(id);
+    if (!pos || now - (pos.ts || 0) > STALE_MS) store.delete(id);
   }
 }, GC_MS);
 


### PR DESCRIPTION
## Summary
- keep combat positioning using stored pixel coordinates for heroes and monsters
- allow combat lookups to reuse recently stale live player positions and expose staleness in telemetry
- extend the live position cache to retain stale entries a bit longer instead of dropping them immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd835f8308327b858016ee65eece2