### PR TITLE
Disperse stacked monsters and enforce AI occupancy

### DIFF
--- a/client/js/engine/pathfinder.js
+++ b/client/js/engine/pathfinder.js
@@ -6,12 +6,17 @@
       this.grid = grid;
       this.cols = cols;
       this.rows = rows;
+      this.dynamicBlocker = null;
     }
 
     isBlocked(cx, cy) {
       if (cx < 0 || cy < 0 || cx >= this.cols || cy >= this.rows) return true;
-      return this.grid[cy * this.cols + cx] === 1;
+      if (this.grid[cy * this.cols + cx] === 1) return true;
+      if (this.dynamicBlocker && this.dynamicBlocker(cx, cy)) return true;
+      return false;
     }
+
+    setDynamicBlocker(fn) { this.dynamicBlocker = (typeof fn === 'function') ? fn : null; }
 
     // Apenas 4 vizinhos cardinais (sem diagonal).
     neighbors(cx, cy) {

--- a/client/js/engine/player_controller.js
+++ b/client/js/engine/player_controller.js
@@ -14,6 +14,8 @@
       this.onMoved = onMoved;             // callback (ex.: publishPos)
       this._accumMoved = 0;               // pixels desde o último autosave (modo contínuo)
 
+      this._dynamicBlocker = null;        // função (cx, cy) => true se houver bloqueio dinâmico
+
       // ====== STEP MODE (WASD — um tile por vez) ======
       this._moving = false;               // está executando um passo de tile?
       this._stepTarget = null;            // { x, y } centro do próximo tile
@@ -21,6 +23,7 @@
     }
 
     setCollision(grid, cols, rows) { this.coll = grid; this.cols = cols; this.rows = rows; }
+    setDynamicBlockChecker(fn) { this._dynamicBlocker = (typeof fn === 'function') ? fn : null; }
     setPosition(x, y) { this.x = x; this.y = y; }
     getPosition() { return { x: this.x, y: this.y }; }
 
@@ -38,9 +41,13 @@
 
     // retorna true se a célula (cx, cy) é sólida
     isBlockedCell(cx, cy) {
-      if (!this.coll) return false;
+      if (!Number.isFinite(this.cols) || !Number.isFinite(this.rows) || this.cols <= 0 || this.rows <= 0) {
+        return !!(this._dynamicBlocker && this._dynamicBlocker(cx, cy));
+      }
       if (cx < 0 || cy < 0 || cx >= this.cols || cy >= this.rows) return true;
-      return this.coll[cy * this.cols + cx] === 1;
+      if (this.coll && this.coll[cy * this.cols + cx] === 1) return true;
+      if (this._dynamicBlocker && this._dynamicBlocker(cx, cy)) return true;
+      return false;
     }
 
     // AABB simples: ocupa 1 tile “central”; pode refinar com bbox se quiser

--- a/client/js/play.js
+++ b/client/js/play.js
@@ -148,6 +148,7 @@ setMapKey(MAP_KEY);
 
 // ----------------- namespace público p/ outros módulos -----------------
 window.GameScene = window.GameScene || {};
+window.GameScene.mapKey = MAP_KEY;
 
 // ======= Time/Hero ativo (base para coleta e combate) =======
 /** Define o herói ativo globalmente e emite evento. */
@@ -223,6 +224,7 @@ window.GameScene.bindInstanceToAnySpriteByKey = (instanceId, monsterKey) => {
   best.hidden = false;
   best._animFrozen = false;
   best._animFrozenFrame = 0;
+  best._serverMove = null;
 
   MOB_BY_INSTANCE.set(String(instanceId), best);
   return best;
@@ -230,6 +232,7 @@ window.GameScene.bindInstanceToAnySpriteByKey = (instanceId, monsterKey) => {
 
 window.GameScene.registerMobSprite = (sprite, meta = {}) => {
   if (!sprite) return;
+  if (sprite._serverMove == null) sprite._serverMove = null;
   if (Number.isFinite(meta.spawnId)) {
     sprite.spawnId = Number(meta.spawnId);
     if (!MOB_SPRITES_BY_SPAWN.has(sprite.spawnId)) MOB_SPRITES_BY_SPAWN.set(sprite.spawnId, new Set());
@@ -239,6 +242,8 @@ window.GameScene.registerMobSprite = (sprite, meta = {}) => {
     sprite.instanceId = String(meta.instanceId);
     MOB_BY_INSTANCE.set(sprite.instanceId, sprite);
   }
+
+  retryBindPendingServerMonsters();
 };
 
 // escolhe uma sprite “livre” daquele spawn
@@ -258,6 +263,7 @@ window.GameScene.bindInstanceToSpawn = (instanceId, spawnId) => {
   s.hidden = false;
   s._animFrozen = false;
   s._animFrozenFrame = 0;
+  s._serverMove = null;
   MOB_BY_INSTANCE.set(String(instanceId), s);
   return s;
 };
@@ -268,8 +274,464 @@ window.GameScene.onMonsterDead = (instanceId) => {
   s.dead = true;
   s._animFrozen = true;
   s._animFrozenFrame = 0;
+  s._serverMove = null;
   MOB_BY_INSTANCE.delete(String(instanceId));
 };
+
+// ======= Server-driven monster state =======
+const SERVER_MONSTER_STATE = new Map(); // id -> { sprite, x, y, spawnId, monsterKey, mapKey, dead, renderX, renderY, animSpeedMultiplier, isMoving, blockKey, tileX, tileY, lastServerAt }
+const UNBOUND_SERVER_MONSTERS = new Set(); // ids aguardando sprite
+const MONSTER_BLOCKED_TILES = new Map(); // "cx,cy" -> Set(instanceId)
+let _serverMonsterRetryScheduled = false;
+
+const SERVER_MONSTER_STEP_MS = 180;
+const SERVER_MONSTER_MIN_TWEEN_MS = 60;
+const SERVER_MONSTER_MAX_TWEEN_MS = 260;
+const SERVER_MONSTER_TELEPORT_THRESHOLD = TILE * 4; // deslocamentos maiores tratam como teleporte
+const SERVER_MONSTER_BASE_SPEED = TILE / (SERVER_MONSTER_STEP_MS / 1000);
+const SERVER_MONSTER_IDLE_ANIM = 0.85;
+const SERVER_MONSTER_MAX_ANIM = 2.2;
+
+function getOrCreateServerMonsterState(id) {
+  const key = String(id);
+  let state = SERVER_MONSTER_STATE.get(key);
+  if (!state) {
+    state = {
+      id: key,
+      sprite: null,
+      x: null,
+      y: null,
+      spawnId: null,
+      monsterKey: null,
+      mapKey: null,
+      dead: false,
+      renderX: null,
+      renderY: null,
+      animSpeedMultiplier: SERVER_MONSTER_IDLE_ANIM,
+      isMoving: false,
+      blockKey: null,
+      tileX: null,
+      tileY: null,
+      lastServerAt: null,
+    };
+    SERVER_MONSTER_STATE.set(key, state);
+  }
+  return state;
+}
+
+function currentSpriteRenderPos(sprite, now = performance.now()) {
+  if (!sprite) return { x: NaN, y: NaN };
+  const mv = sprite._serverMove;
+  if (!mv || !Number.isFinite(mv.duration) || mv.duration <= 0) {
+    return {
+      x: Number.isFinite(sprite.x) ? sprite.x : NaN,
+      y: Number.isFinite(sprite.y) ? sprite.y : NaN,
+    };
+  }
+
+  const elapsed = now - mv.startAt;
+  if (elapsed <= 0) {
+    return { x: mv.fromX, y: mv.fromY };
+  }
+
+  const t = Math.max(0, Math.min(1, elapsed / mv.duration));
+  return {
+    x: mv.fromX + (mv.toX - mv.fromX) * t,
+    y: mv.fromY + (mv.toY - mv.fromY) * t,
+  };
+}
+
+function computeTweenDuration(dx, dy) {
+  const dist = Math.hypot(dx, dy);
+  if (!Number.isFinite(dist) || dist < 1) return 0;
+  const tiles = Math.max(1, dist / TILE);
+  const base = SERVER_MONSTER_STEP_MS * tiles;
+  return Math.max(SERVER_MONSTER_MIN_TWEEN_MS, Math.min(SERVER_MONSTER_MAX_TWEEN_MS, base));
+}
+
+function monsterTileKey(cx, cy) {
+  return `${cx | 0},${cy | 0}`;
+}
+
+function removeMonsterFromTile(state) {
+  if (!state || !state.blockKey) return;
+  const set = MONSTER_BLOCKED_TILES.get(state.blockKey);
+  if (set) {
+    set.delete(state.id);
+    if (!set.size) MONSTER_BLOCKED_TILES.delete(state.blockKey);
+  }
+  state.blockKey = null;
+  state.tileX = null;
+  state.tileY = null;
+}
+
+function updateMonsterBlocking(state, cx, cy) {
+  if (!state) return;
+  removeMonsterFromTile(state);
+  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return;
+  const ix = Math.floor(cx);
+  const iy = Math.floor(cy);
+  const key = monsterTileKey(ix, iy);
+  let set = MONSTER_BLOCKED_TILES.get(key);
+  if (!set) {
+    set = new Set();
+    MONSTER_BLOCKED_TILES.set(key, set);
+  }
+  set.add(state.id);
+  state.blockKey = key;
+  state.tileX = ix;
+  state.tileY = iy;
+}
+
+function clearMonsterBlocking(id) {
+  const state = SERVER_MONSTER_STATE.get(String(id));
+  if (!state) return;
+  removeMonsterFromTile(state);
+}
+
+function isTileBlockedByMonster(cx, cy) {
+  const key = monsterTileKey(cx, cy);
+  const set = MONSTER_BLOCKED_TILES.get(key);
+  if (!set || !set.size) return false;
+  let alive = false;
+  for (const id of set) {
+    const st = SERVER_MONSTER_STATE.get(String(id));
+    if (st && !st.dead && (!st.mapKey || st.mapKey === MAP_KEY)) {
+      alive = true;
+      break;
+    }
+  }
+  if (!alive) MONSTER_BLOCKED_TILES.delete(key);
+  return alive;
+}
+
+function msgMatchesCurrentMap(msg = {}) {
+  if (!msg || msg.mapKey == null) return true;
+  try {
+    return String(msg.mapKey) === MAP_KEY;
+  } catch {
+    return false;
+  }
+}
+
+function ensureServerMonsterSprite(msg = {}) {
+  const rawId = msg.id != null ? msg.id : (msg.instanceId != null ? msg.instanceId : null);
+  if (rawId == null) return null;
+  const id = String(rawId);
+
+  const state = getOrCreateServerMonsterState(id);
+  if (msg.mapKey != null) state.mapKey = String(msg.mapKey);
+  if (msg.spawnId != null && Number.isFinite(Number(msg.spawnId))) state.spawnId = Number(msg.spawnId);
+  if (msg.monsterKey) state.monsterKey = String(msg.monsterKey);
+  state.dead = false;
+
+  let sprite = window.GameScene?.getMobByInstanceId?.(id) || state.sprite || null;
+
+  if (!sprite && state.spawnId != null && window.GameScene?.bindInstanceToSpawn) {
+    sprite = window.GameScene.bindInstanceToSpawn(id, Number(state.spawnId));
+  }
+
+  if (!sprite && msg.spawnId != null && window.GameScene?.bindInstanceToSpawn) {
+    sprite = window.GameScene.bindInstanceToSpawn(id, Number(msg.spawnId));
+  }
+
+  const keyCandidate = state.monsterKey || (msg.monsterKey ? String(msg.monsterKey) : null);
+  if (!sprite && keyCandidate && window.GameScene?.bindInstanceToAnySpriteByKey) {
+    sprite = window.GameScene.bindInstanceToAnySpriteByKey(id, keyCandidate);
+  }
+
+  if (sprite) {
+    if (keyCandidate && !sprite.rawKey) sprite.rawKey = keyCandidate;
+    sprite.dead = false;
+    sprite.hidden = false;
+    sprite._animFrozen = false;
+    sprite._animFrozenFrame = 0;
+    if (!Number.isFinite(state.animSpeedMultiplier)) state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+    sprite._animSpeedMultiplier = state.animSpeedMultiplier;
+    sprite._animIsMoving = !!state.isMoving;
+    if (!sprite._serverMove) sprite._serverMove = null;
+    state.sprite = sprite;
+    SERVER_MONSTER_STATE.set(id, state);
+    UNBOUND_SERVER_MONSTERS.delete(id);
+    return sprite;
+  }
+
+  SERVER_MONSTER_STATE.set(id, state);
+  UNBOUND_SERVER_MONSTERS.add(id);
+  scheduleServerMonsterRetry();
+  return null;
+}
+
+function updateSpriteFacingFromDelta(sprite, dx, dy) {
+  if (!sprite || (!Number.isFinite(dx) && !Number.isFinite(dy))) return;
+  const absDx = Math.abs(dx);
+  const absDy = Math.abs(dy);
+  if (absDx < 0.5 && absDy < 0.5) return; // movimento insignificante
+
+  if (absDx >= absDy) {
+    if (dx > 0.5) sprite.face = 'east';
+    else if (dx < -0.5) sprite.face = 'west';
+  } else {
+    if (dy > 0.5) sprite.face = 'south';
+    else if (dy < -0.5) sprite.face = 'north';
+  }
+}
+
+function applyServerPosition(id, sprite, x, y) {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+  const state = getOrCreateServerMonsterState(id);
+  const now = performance.now();
+
+  const current = sprite ? currentSpriteRenderPos(sprite, now) : {
+    x: Number.isFinite(state.renderX) ? state.renderX : (Number.isFinite(state.x) ? state.x : x),
+    y: Number.isFinite(state.renderY) ? state.renderY : (Number.isFinite(state.y) ? state.y : y),
+  };
+
+  const prevX = Number.isFinite(current.x) ? current.x : (Number.isFinite(state.renderX) ? state.renderX : x);
+  const prevY = Number.isFinite(current.y) ? current.y : (Number.isFinite(state.renderY) ? state.renderY : y);
+
+  const dx = x - prevX;
+  const dy = y - prevY;
+  const dist = Math.hypot(dx, dy);
+
+  let tweenDur = computeTweenDuration(dx, dy);
+  const prevServerAt = Number.isFinite(state.lastServerAt) ? state.lastServerAt : null;
+  const serverDelta = (prevServerAt != null) ? Math.max(30, now - prevServerAt) : null;
+  if (serverDelta != null && Number.isFinite(serverDelta)) {
+    const cap = Math.max(SERVER_MONSTER_MIN_TWEEN_MS, Math.min(SERVER_MONSTER_MAX_TWEEN_MS, serverDelta * 0.92));
+    if (tweenDur > cap) tweenDur = cap;
+  }
+
+  const shouldTeleport = !Number.isFinite(dist) || dist < 1 || dist > SERVER_MONSTER_TELEPORT_THRESHOLD;
+
+  let animMultiplier = SERVER_MONSTER_IDLE_ANIM;
+  let isMoving = false;
+  if (!shouldTeleport && tweenDur > 0 && dist >= 1) {
+    const pxPerSec = dist / (tweenDur / 1000);
+    if (Number.isFinite(pxPerSec) && SERVER_MONSTER_BASE_SPEED > 0) {
+      const ratio = pxPerSec / SERVER_MONSTER_BASE_SPEED;
+      animMultiplier = Math.max(SERVER_MONSTER_IDLE_ANIM, Math.min(SERVER_MONSTER_MAX_ANIM, ratio));
+    } else {
+      animMultiplier = 1;
+    }
+    isMoving = true;
+  }
+
+  state.x = x;
+  state.y = y;
+  state.dead = false;
+  state.animSpeedMultiplier = animMultiplier;
+  state.isMoving = isMoving;
+
+  if (sprite) {
+    sprite._animFrozen = false;
+    sprite.hidden = false;
+    sprite.dead = false;
+    sprite._animSpeedMultiplier = animMultiplier;
+    sprite._animIsMoving = isMoving;
+    state.sprite = sprite;
+    UNBOUND_SERVER_MONSTERS.delete(String(id));
+
+    if (shouldTeleport || tweenDur <= 0) {
+      sprite._serverMove = null;
+      sprite.x = x;
+      sprite.y = y;
+      updateSpriteFacingFromDelta(sprite, dx, dy);
+      state.renderX = x;
+      state.renderY = y;
+    } else {
+      const fromX = prevX;
+      const fromY = prevY;
+      updateSpriteFacingFromDelta(sprite, dx, dy);
+      sprite._serverMove = {
+        fromX,
+        fromY,
+        toX: x,
+        toY: y,
+        startAt: now,
+        duration: tweenDur,
+      };
+      sprite.x = fromX;
+      sprite.y = fromY;
+      state.renderX = fromX;
+      state.renderY = fromY;
+    }
+  } else {
+    state.sprite = null;
+    state.renderX = x;
+    state.renderY = y;
+  }
+
+  updateMonsterBlocking(state, x / TILE, y / TILE);
+  state.lastServerAt = now;
+  SERVER_MONSTER_STATE.set(String(id), state);
+}
+
+function updateServerDrivenMonsters(now = performance.now()) {
+  for (const state of SERVER_MONSTER_STATE.values()) {
+    const sprite = state.sprite;
+    if (!sprite) continue;
+
+    const mv = sprite._serverMove;
+    if (!mv || !Number.isFinite(mv.duration) || mv.duration <= 0) {
+      if (Number.isFinite(state.x)) sprite.x = state.x;
+      if (Number.isFinite(state.y)) sprite.y = state.y;
+      state.renderX = Number.isFinite(sprite.x) ? sprite.x : state.x;
+      state.renderY = Number.isFinite(sprite.y) ? sprite.y : state.y;
+      sprite._serverMove = null;
+      if (!Number.isFinite(state.animSpeedMultiplier)) state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+      sprite._animSpeedMultiplier = state.animSpeedMultiplier;
+      sprite._animIsMoving = !!state.isMoving;
+      continue;
+    }
+
+    const elapsed = now - mv.startAt;
+    if (elapsed <= 0) {
+      sprite.x = mv.fromX;
+      sprite.y = mv.fromY;
+      state.renderX = sprite.x;
+      state.renderY = sprite.y;
+      continue;
+    }
+
+    const t = Math.max(0, Math.min(1, elapsed / mv.duration));
+    sprite.x = mv.fromX + (mv.toX - mv.fromX) * t;
+    sprite.y = mv.fromY + (mv.toY - mv.fromY) * t;
+    state.renderX = sprite.x;
+    state.renderY = sprite.y;
+
+    if (t >= 1) {
+      sprite._serverMove = null;
+      sprite.x = mv.toX;
+      sprite.y = mv.toY;
+      state.renderX = sprite.x;
+      state.renderY = sprite.y;
+      state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+      state.isMoving = false;
+      sprite._animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+      sprite._animIsMoving = false;
+    }
+  }
+}
+
+function retryBindPendingServerMonsters() {
+  if (!UNBOUND_SERVER_MONSTERS.size) return;
+  for (const id of Array.from(UNBOUND_SERVER_MONSTERS)) {
+    const state = SERVER_MONSTER_STATE.get(String(id));
+    if (!state || state.dead) {
+      UNBOUND_SERVER_MONSTERS.delete(id);
+      continue;
+    }
+
+    const sprite = ensureServerMonsterSprite({
+      id,
+      spawnId: state.spawnId,
+      monsterKey: state.monsterKey,
+      mapKey: state.mapKey,
+    });
+
+    if (!sprite) continue;
+
+    if (Number.isFinite(state.x) && Number.isFinite(state.y)) {
+      applyServerPosition(id, sprite, state.x, state.y);
+    } else {
+      if (!Number.isFinite(state.animSpeedMultiplier)) state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+      sprite._animSpeedMultiplier = state.animSpeedMultiplier;
+      sprite._animIsMoving = !!state.isMoving;
+      state.sprite = sprite;
+      SERVER_MONSTER_STATE.set(String(id), state);
+    }
+
+    UNBOUND_SERVER_MONSTERS.delete(id);
+  }
+}
+
+function scheduleServerMonsterRetry() {
+  if (_serverMonsterRetryScheduled) return;
+  _serverMonsterRetryScheduled = true;
+  setTimeout(() => {
+    _serverMonsterRetryScheduled = false;
+    try { retryBindPendingServerMonsters(); } catch (e) { console.warn('[mobs] retry bind failed', e?.message); }
+  }, 0);
+}
+
+function handleServerMonsterRespawn(msg = {}) {
+  if (!msgMatchesCurrentMap(msg)) return;
+  const id = msg.id != null ? String(msg.id) : null;
+  if (!id) return;
+
+  const sprite = ensureServerMonsterSprite(msg);
+
+  const x = Number(msg.x);
+  const y = Number(msg.y);
+  if (sprite && Number.isFinite(x) && Number.isFinite(y)) {
+    applyServerPosition(id, sprite, x, y);
+  } else if (Number.isFinite(x) && Number.isFinite(y)) {
+    applyServerPosition(id, null, x, y);
+  }
+}
+
+function handleServerMonsterMove(msg = {}) {
+  if (!msgMatchesCurrentMap(msg)) return;
+  const id = msg.id != null ? String(msg.id) : null;
+  if (!id) return;
+
+  const x = Number(msg.x);
+  const y = Number(msg.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+
+  const sprite = ensureServerMonsterSprite(msg);
+  if (sprite) {
+    applyServerPosition(id, sprite, x, y);
+  } else {
+    applyServerPosition(id, null, x, y);
+  }
+}
+
+function handleServerMonsterDead(msg = {}) {
+  if (!msgMatchesCurrentMap(msg)) return;
+  const id = msg.id != null ? String(msg.id) : null;
+  if (!id) return;
+
+  const state = getOrCreateServerMonsterState(id);
+  state.dead = true;
+  state.sprite = null;
+  state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+  state.isMoving = false;
+  SERVER_MONSTER_STATE.set(id, state);
+  UNBOUND_SERVER_MONSTERS.delete(id);
+  clearMonsterBlocking(id);
+
+  try { window.GameScene?.onMonsterDead?.(id); } catch {}
+}
+
+function normalizeLegacyMobPos(msg = {}) {
+  const id = msg.instanceId != null ? String(msg.instanceId) : (msg.id != null ? String(msg.id) : null);
+  if (!id) return null;
+
+  return {
+    id,
+    x: Number(msg.x),
+    y: Number(msg.y),
+    mapKey: msg.mapKey ?? msg.map_key ?? null,
+    spawnId: msg.spawnId ?? msg.spawn_id ?? null,
+    monsterKey: msg.monsterKey ?? msg.monster_key ?? null,
+  };
+}
+
+function handleLegacyMobPos(msg = {}) {
+  const normalized = normalizeLegacyMobPos(msg);
+  if (!normalized) return;
+  handleServerMonsterMove(normalized);
+}
+
+onMessage('monster_respawned', handleServerMonsterRespawn);
+onMessage('monster_move', handleServerMonsterMove);
+onMessage('mob_pos', handleLegacyMobPos);
+onMessage('monster_dead', handleServerMonsterDead);
+window.GameScene.serverMonsters = SERVER_MONSTER_STATE;
+window.GameScene.isTileBlockedByMonster = isTileBlockedByMonster;
+window.GameScene.monsterBlockedTiles = MONSTER_BLOCKED_TILES;
 
 // =============== Canvas/HUD flexível (querystring + auto) ===============
 function pickElByIds(prefIds = [], fallbackSelectors = []) {
@@ -627,6 +1089,11 @@ function drawMob(m) {
   const face = m.face || 'south';
   let anim = m.dead && animDead ? animDead : (animIdle && m._animFrozen ? animIdle : animWalk);
   let fps = Number(anim.fps); if (!Number.isFinite(fps) || fps < 0) fps = 8;
+  if (!Number.isFinite(m._animSpeedMultiplier)) m._animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
+  if (!m.dead) {
+    const speedMult = Math.max(0, Number(m._animSpeedMultiplier));
+    fps *= speedMult;
+  }
 
   let seq = Array.isArray(anim.seq) ? anim.seq.slice() : null;
   let frames = Number(anim.frames);
@@ -1012,6 +1479,8 @@ function updateRespawns(now) {
 
   resize();
 
+  const monsterBlockChecker = (cx, cy) => isTileBlockedByMonster(cx, cy);
+
   const controller = new PlayerController({
     speed: 140,
     collisionGrid: grid,
@@ -1025,10 +1494,15 @@ function updateRespawns(now) {
     },
   });
 
+  if (typeof controller.setDynamicBlockChecker === 'function') {
+    controller.setDynamicBlockChecker(monsterBlockChecker);
+  }
+
   // expõe camera/controller/mapKey p/ outros módulos (combate, etc.)
   window.GameScene.camera = camera;
   window.GameScene.controller = controller;
   window.GameScene.mapKey = MAP_KEY;
+  window.GameScene.monsterBlockChecker = monsterBlockChecker;
 
   // ==== Posição inicial: prioridade = pos_snap do servidor -> localStorage -> spawn ====
   // 2.1) tenta aplicar um pos_snap que pode ter chegado antes do controller existir
@@ -1066,6 +1540,9 @@ function updateRespawns(now) {
 
   // === A* e click-to-move (pode ficar logo depois da posição inicial)
   const astar = new AStarGrid(grid, cols, rows);
+  if (typeof astar.setDynamicBlocker === 'function') {
+    astar.setDynamicBlocker(monsterBlockChecker);
+  }
   const clickMove = new ClickToMove({ canvas, camera, controller, grid });
   clickMove.setAStar(astar);
 
@@ -1164,6 +1641,7 @@ function updateRespawns(now) {
 
 
     updateRespawns(now);
+    updateServerDrivenMonsters(now);
 
     // Render
     clear();

--- a/data/monsters/bear.yml
+++ b/data/monsters/bear.yml
@@ -8,6 +8,7 @@ look:
   spriteKey: bear
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 attacks:

--- a/data/monsters/cave_rat.yml
+++ b/data/monsters/cave_rat.yml
@@ -9,6 +9,7 @@ look:
   defaultAnim: idle
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 attacks:

--- a/data/monsters/deer.yml
+++ b/data/monsters/deer.yml
@@ -8,6 +8,7 @@ look:
   spriteKey: deer
 flags:
   hostile: false
+  pushable: false
 elements:
   physical: 0
 attacks:

--- a/data/monsters/demon_bonefiend.yml
+++ b/data/monsters/demon_bonefiend.yml
@@ -9,6 +9,7 @@ look:
   spriteKey: demon_bonefiend
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 

--- a/data/monsters/goblin.yml
+++ b/data/monsters/goblin.yml
@@ -6,6 +6,9 @@ health:
 speed: 80
 look:
   spriteKey: goblin
+flags:
+  hostile: true
+  pushable: false
 attacks:
 - type: melee
   intervalMs: 1800

--- a/data/monsters/rat.yml
+++ b/data/monsters/rat.yml
@@ -9,6 +9,7 @@ look:
   spriteKey: rat
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 attacks:

--- a/data/monsters/rotmaw.yml
+++ b/data/monsters/rotmaw.yml
@@ -9,6 +9,7 @@ look:
   spriteKey: rotmaw
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 

--- a/data/monsters/rotworm.yml
+++ b/data/monsters/rotworm.yml
@@ -9,6 +9,7 @@ look:
   spriteKey: rotmaw
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 attacks:

--- a/data/monsters/wolf.yml
+++ b/data/monsters/wolf.yml
@@ -9,6 +9,7 @@ look:
   spriteKey: wolf
 flags:
   hostile: true
+  pushable: false
 elements:
   physical: 0
 

--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -340,6 +340,198 @@
   }
 
   // --------- Loop principal ----------
+  const CARDINAL_DIRS = [
+    { dx: 1, dy: 0 },
+    { dx: -1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: 0, dy: -1 },
+  ];
+
+  function tileKey(cx, cy) {
+    return `${cx}|${cy}`;
+  }
+
+  function losGridRows(losGrid) {
+    if (!losGrid || !losGrid.cols) return 0;
+    return Math.floor(losGrid.data.length / losGrid.cols);
+  }
+
+  function isSolidTile(losGrid, cx, cy) {
+    if (!losGrid || !losGrid.data) return false;
+    if (cx < 0 || cy < 0) return true;
+    if (cx >= losGrid.cols) return true;
+    const rows = losGridRows(losGrid);
+    if (cy >= rows) return true;
+    const idx = cy * losGrid.cols + cx;
+    return losGrid.data[idx] === 1;
+  }
+
+  function isTileBlockedByMobs(occupancy, cx, cy, ignoreId) {
+    if (!occupancy) return false;
+    const key = tileKey(cx, cy);
+    const set = occupancy.get(key);
+    if (!set || set.size === 0) return false;
+    if (set.size === 1 && set.has(ignoreId)) return false;
+    return true;
+  }
+
+  function buildHeroTileSet(heroes) {
+    const res = new Set();
+    if (!Array.isArray(heroes)) return res;
+    for (const h of heroes) {
+      const cx = Math.floor(Number(h?.x) / STEP_PX);
+      const cy = Math.floor(Number(h?.y) / STEP_PX);
+      if (!Number.isFinite(cx) || !Number.isFinite(cy)) continue;
+      res.add(tileKey(cx, cy));
+    }
+    return res;
+  }
+
+  function buildMobOccupancy(list) {
+    const occ = new Map();
+    if (!Array.isArray(list)) return occ;
+    for (const mob of list) {
+      const cx = Math.floor(Number(mob?.x) / STEP_PX);
+      const cy = Math.floor(Number(mob?.y) / STEP_PX);
+      if (!Number.isFinite(cx) || !Number.isFinite(cy)) continue;
+      mob._tileCx = cx;
+      mob._tileCy = cy;
+      mob._tileKey = tileKey(cx, cy);
+      let set = occ.get(mob._tileKey);
+      if (!set) {
+        set = new Set();
+        occ.set(mob._tileKey, set);
+      }
+      set.add(mob.instanceId);
+    }
+    return occ;
+  }
+
+  function findNearestFreeTile({
+    startCx,
+    startCy,
+    occupancy,
+    heroTiles,
+    losGrid,
+    ignoreId,
+    maxDepth = 8,
+  }) {
+    const queue = [{ cx: startCx, cy: startCy, depth: 0 }];
+    const visited = new Set([tileKey(startCx, startCy)]);
+
+    while (queue.length) {
+      const node = queue.shift();
+      if (node.depth >= maxDepth) continue;
+
+      for (const dir of CARDINAL_DIRS) {
+        const nx = node.cx + dir.dx;
+        const ny = node.cy + dir.dy;
+        if (isSolidTile(losGrid, nx, ny)) continue;
+        const k = tileKey(nx, ny);
+        if (visited.has(k)) continue;
+        visited.add(k);
+        if (heroTiles && heroTiles.has(k)) {
+          // evita ocupar o mesmo tile que o herói, mas pode explorar ao redor
+          queue.push({ cx: nx, cy: ny, depth: node.depth + 1 });
+          continue;
+        }
+
+        const blocked = isTileBlockedByMobs(occupancy, nx, ny, ignoreId);
+        if (!blocked) {
+          return { cx: nx, cy: ny };
+        }
+
+        queue.push({ cx: nx, cy: ny, depth: node.depth + 1 });
+      }
+    }
+    return null;
+  }
+
+  async function teleportMobToTile({ mob, cx, cy, occupancy }) {
+    if (!mob) return;
+    const prevCx = Math.floor(Number(mob.x) / STEP_PX);
+    const prevCy = Math.floor(Number(mob.y) / STEP_PX);
+    const prevKey = tileKey(prevCx, prevCy);
+
+    const px = cx * STEP_PX + STEP_PX / 2;
+    const py = cy * STEP_PX + STEP_PX / 2;
+    mob.x = px | 0;
+    mob.y = py | 0;
+    mob.posUpdatedAt = Date.now();
+
+    if (occupancy) {
+      const prevSet = occupancy.get(prevKey);
+      if (prevSet) {
+        prevSet.delete(mob.instanceId);
+        if (!prevSet.size) occupancy.delete(prevKey);
+      }
+
+      const destKey = tileKey(cx, cy);
+      let set = occupancy.get(destKey);
+      if (!set) {
+        set = new Set();
+        occupancy.set(destKey, set);
+      }
+      set.add(mob.instanceId);
+
+      mob._tileCx = cx;
+      mob._tileCy = cy;
+      mob._tileKey = destKey;
+    }
+
+    try {
+      await run(
+        `UPDATE monster_instances SET x=$2, y=$3, updated_at=now() WHERE id=$1`,
+        [mob.instanceId, mob.x | 0, mob.y | 0]
+      );
+      try {
+        broadcast({ type: 'mob_pos', instanceId: mob.instanceId, mapKey: mob.mapKey, x: mob.x, y: mob.y });
+      } catch {}
+    } catch (e) {
+      console.warn('[ai-mobs] teleport persist error:', e?.message);
+    }
+  }
+
+  async function resolveMobStacks({ mobsInMap, occupancy, heroTiles, losGrid }) {
+    if (!Array.isArray(mobsInMap) || mobsInMap.length === 0) return;
+    const stacks = new Map();
+    for (const mob of mobsInMap) {
+      if (!mob || mob._tileKey == null) continue;
+      if (!stacks.has(mob._tileKey)) stacks.set(mob._tileKey, []);
+      stacks.get(mob._tileKey).push(mob);
+    }
+
+    for (const [key, stack] of stacks.entries()) {
+      if (!Array.isArray(stack) || stack.length <= 1) continue;
+      // mantém o primeiro no tile atual, desloca os demais
+      stack.sort((a, b) => {
+        const ia = Number(a?.instanceId) || 0;
+        const ib = Number(b?.instanceId) || 0;
+        return ia - ib;
+      });
+
+      for (let i = 1; i < stack.length; i++) {
+        const mob = stack[i];
+        const startCx = mob?._tileCx;
+        const startCy = mob?._tileCy;
+        if (!Number.isFinite(startCx) || !Number.isFinite(startCy)) continue;
+
+        const free = findNearestFreeTile({
+          startCx,
+          startCy,
+          occupancy,
+          heroTiles,
+          losGrid,
+          ignoreId: mob.instanceId,
+          maxDepth: 10,
+        });
+
+        if (!free) continue;
+        await teleportMobToTile({ mob, cx: free.cx, cy: free.cy, occupancy });
+      }
+    }
+  }
+
   async function tickLoop() {
     const now = Date.now();
     const dt = Math.min(0.25, (now - lastTickAt) / 1000);
@@ -356,9 +548,13 @@
     for (const [mapKey, list] of byMap.entries()) {
       const heroes = await fetchOnlineHeroesInMap(mapKey);
 
+      const heroTiles = buildHeroTileSet(heroes);
 
       const { grid, cols } = await getGrid(mapKey);
       const losGrid = { data: grid, cols };
+      const occupancy = buildMobOccupancy(list);
+
+      await resolveMobStacks({ mobsInMap: list, occupancy, heroTiles, losGrid });
 
       if (DEBUG_AI) {
         console.log(`[ai-mobs] tick map=${mapKey} heroes=${heroes.length} mobs=${list.length}`);
@@ -369,7 +565,7 @@
 
       for (const mob of list) {
         try {
-          await stepMob(now, dt, mob, heroes, losGrid);
+          await stepMob(now, dt, mob, heroes, losGrid, occupancy, heroTiles);
         } catch (e) {
           console.warn('[ai-mobs] stepMob error:', e?.message);
         }
@@ -377,7 +573,7 @@
     }
   }
 
-async function stepMob(now, dt, mob, heroes, losGrid) {
+async function stepMob(now, dt, mob, heroes, losGrid, occupancy, heroTiles) {
   decayThreat(mob, dt);
   selectTargetByThreat(now, mob, heroes, losGrid);
 
@@ -485,8 +681,8 @@ async function stepMob(now, dt, mob, heroes, losGrid) {
   mob.mode = 'chase';
   if (now >= mob.repathAt) {
     mob.repathAt = now + REPATH_MS;
-    const step = pickStepGreedy(mob, tgtPos, losGrid);
-    if (step) await moveMobAndPersist(mob, step, dt, losGrid);
+    const step = pickStepGreedy(mob, tgtPos, losGrid, occupancy, heroTiles);
+    if (step) await moveMobAndPersist(mob, step, dt, losGrid, occupancy);
   }
 
 }
@@ -576,7 +772,7 @@ async function stepMob(now, dt, mob, heroes, losGrid) {
     return losGrid.data[cy * losGrid.cols + cx] === 1;
   }
 
-  function pickStepGreedy(mob, tgtPos, losGrid) {
+  function pickStepGreedy(mob, tgtPos, losGrid, occupancy, heroTiles) {
     const c0x = Math.floor(mob.x / STEP_PX), c0y = Math.floor(mob.y / STEP_PX);
     const c1x = Math.floor(tgtPos.x / STEP_PX), c1y = Math.floor(tgtPos.y / STEP_PX);
     const dx = Math.sign(c1x - c0x), dy = Math.sign(c1y - c0y);
@@ -599,10 +795,36 @@ async function stepMob(now, dt, mob, heroes, losGrid) {
       console.log(`[ai-mobs] path cand mob=${mob.instanceId} -> ${dbg}`);
     }
 
+    const allCand = [];
+    const seen = new Set();
     for (const c of cand) {
+      const key = tileKey(c.cx, c.cy);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      allCand.push(c);
+    }
+
+    // fallback: tenta os outros dois cardinais (caso prioridade inicial esteja bloqueada)
+    const fallback = [
+      { cx: c0x + 1, cy: c0y },
+      { cx: c0x - 1, cy: c0y },
+      { cx: c0x,     cy: c0y + 1 },
+      { cx: c0x,     cy: c0y - 1 },
+    ];
+    for (const f of fallback) {
+      const key = tileKey(f.cx, f.cy);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      allCand.push(f);
+    }
+
+    for (const c of allCand) {
       const wx = c.cx * STEP_PX + STEP_PX/2;
       const wy = c.cy * STEP_PX + STEP_PX/2;
-      if (!isBlockedPx(losGrid, wx, wy)) return { x: wx, y: wy };
+      if (isBlockedPx(losGrid, wx, wy)) continue;
+      if (heroTiles && heroTiles.has(tileKey(c.cx, c.cy))) continue;
+      if (isTileBlockedByMobs(occupancy, c.cx, c.cy, mob.instanceId)) continue;
+      return { x: wx, y: wy };
     }
     if (DEBUG_AI) console.log(`[ai-mobs] path blocked mob=${mob.instanceId}`);
     return null;
@@ -619,7 +841,7 @@ function clampToMapPx(losGrid, px) {
   };
 }
 
-async function moveMobAndPersist(mob, step, dt, losGrid) {
+async function moveMobAndPersist(mob, step, dt, losGrid, occupancy) {
   const speed = CHASE_SPEED_PX_S;
   const maxMove = speed * dt;
 
@@ -629,16 +851,36 @@ async function moveMobAndPersist(mob, step, dt, losGrid) {
   const nx = dist <= maxMove ? step.x : (mob.x + ux * maxMove);
   const ny = dist <= maxMove ? step.y : (mob.y + uy * maxMove);
 
-  const prevCell = (Math.floor(mob.x/STEP_PX) << 16) | Math.floor(mob.y/STEP_PX);
+  const prevCx = Math.floor(mob.x / STEP_PX);
+  const prevCy = Math.floor(mob.y / STEP_PX);
 
   // clamp dentro do mapa (evita OOB por arredondamento/velocidade)
   const clamped = losGrid ? clampToMapPx(losGrid, { x: nx|0, y: ny|0 }) : { x: nx|0, y: ny|0 };
   mob.x = clamped.x; mob.y = clamped.y;
   mob.posUpdatedAt = Date.now(); // <<< posição do mob ficou "fresca" agora
 
-  const nextCell = (Math.floor(mob.x/STEP_PX) << 16) | Math.floor(mob.y/STEP_PX);
+  const nextCx = Math.floor(mob.x / STEP_PX);
+  const nextCy = Math.floor(mob.y / STEP_PX);
 
-  if (prevCell !== nextCell) {
+  if (prevCx !== nextCx || prevCy !== nextCy) {
+    if (occupancy) {
+      const prevKey = tileKey(prevCx, prevCy);
+      const prevSet = occupancy.get(prevKey);
+      if (prevSet) {
+        prevSet.delete(mob.instanceId);
+        if (!prevSet.size) occupancy.delete(prevKey);
+      }
+      const nextKey = tileKey(nextCx, nextCy);
+      let set = occupancy.get(nextKey);
+      if (!set) {
+        set = new Set();
+        occupancy.set(nextKey, set);
+      }
+      set.add(mob.instanceId);
+      mob._tileCx = nextCx;
+      mob._tileCy = nextCy;
+      mob._tileKey = nextKey;
+    }
     try {
       await run(
         `UPDATE monster_instances SET x=$2, y=$3, updated_at=now() WHERE id=$1`,

--- a/server/combat/monster_atk_simple.js
+++ b/server/combat/monster_atk_simple.js
@@ -25,6 +25,9 @@ const CHASE_MAX_TILES = +(process.env.MONSTER_CHASE_MAX_TILES || 25);
 
 // Evita processar monstro demais por tick (alivia pool)
 const MONSTER_MAX_PER_TICK = +(process.env.MONSTER_MAX_PER_TICK || 40);
+const MONSTER_SEARCH_DEPTH = +(process.env.MONSTER_STEP_SEARCH_DEPTH || 4);
+const MONSTER_STEP_BACKTRACK_PENALTY = +(process.env.MONSTER_STEP_BACKTRACK_PENALTY || 2);
+const MONSTER_STACK_RESOLVE_DEPTH = +(process.env.MONSTER_STACK_RESOLVE_DEPTH || 6);
 
 // ======= Estado em RAM =======
 let timer = null;
@@ -34,11 +37,43 @@ const _lastAtkAt      = new Map(); // monsterId -> ms
 const _lastMoveAt     = new Map(); // monsterId -> ms
 const _lastPosWriteAt = new Map(); // monsterId -> ms
 const _wasQuantized   = new Set(); // monsterId -> bool
+const _livePos        = new Map(); // monsterId -> { x, y, mapKey }
 
 // ======= Utils =======
 function rand(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
 const tileOf = (v) => Math.floor(Number(v || 0) / TILE);
 const centerOfTile = (t) => (t * TILE) + TILE / 2;
+const tileKey = (tx, ty) => `${tx},${ty}`;
+
+function buildMonsterTileMap(list = []) {
+  const byMap = new Map();
+  for (const m of list) {
+    const mapKey = m?.map_key == null ? '__null__' : String(m.map_key);
+    const tx = tileOf(m?.x);
+    const ty = tileOf(m?.y);
+    if (!Number.isFinite(tx) || !Number.isFinite(ty)) continue;
+    if (!byMap.has(mapKey)) byMap.set(mapKey, new Map());
+    const grid = byMap.get(mapKey);
+    const key = tileKey(tx, ty);
+    let set = grid.get(key);
+    if (!set) { set = new Set(); grid.set(key, set); }
+    set.add(m.id);
+  }
+  return byMap;
+}
+
+function buildHeroTileSet(list = []) {
+  const byMap = new Map();
+  for (const h of list) {
+    const mapKey = h?.map_key == null ? '__null__' : String(h.map_key);
+    const tx = tileOf(h?.x);
+    const ty = tileOf(h?.y);
+    if (!Number.isFinite(tx) || !Number.isFinite(ty)) continue;
+    if (!byMap.has(mapKey)) byMap.set(mapKey, new Set());
+    byMap.get(mapKey).add(tileKey(tx, ty));
+  }
+  return byMap;
+}
 
 function isAdjacent4Tiles(mx, my, hx, hy) {
   const dx = Math.abs(mx - hx);
@@ -55,34 +90,241 @@ function isInsideSpawnRect(hx, hy, m, pad = 0) {
          hy >= sy - pad && hy <= sy + sh + pad;
 }
 
-function nextTileToward(mx, my, hx, hy, m) {
-  const dxTiles = hx - mx;
-  const dyTiles = hy - my;
-  if (dxTiles === 0 && dyTiles === 0) return { nx: mx, ny: my, moved: false };
+function isTileInsideSpawn(tx, ty, m) {
+  if (!CHASE_INSIDE_SPAWN_ONLY) return true;
+  const sx = Number(m.sx) | 0, sy = Number(m.sy) | 0;
+  const sw = Math.max(1, Number(m.sw) || 32);
+  const sh = Math.max(1, Number(m.sh) || 32);
+  const minTx = tileOf(sx);
+  const maxTx = tileOf(sx + sw - 1);
+  const minTy = tileOf(sy);
+  const maxTy = tileOf(sy + sh - 1);
+  return tx >= minTx && tx <= maxTx && ty >= minTy && ty <= maxTy;
+}
 
-  const preferX = Math.abs(dxTiles) >= Math.abs(dyTiles);
-  const tryDirs = preferX
-    ? [{ dx: Math.sign(dxTiles), dy: 0 }, { dx: 0, dy: Math.sign(dyTiles) }]
-    : [{ dx: 0, dy: Math.sign(dyTiles) }, { dx: Math.sign(dxTiles), dy: 0 }];
+const CARDINAL_STEPS = [
+  { dx: 1, dy: 0 },
+  { dx: -1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: 0, dy: -1 },
+];
 
-  let minTx = -Infinity, maxTx = Infinity, minTy = -Infinity, maxTy = Infinity;
-  if (CHASE_INSIDE_SPAWN_ONLY) {
-    const sx = Number(m.sx) | 0, sy = Number(m.sy) | 0;
-    const sw = Math.max(1, Number(m.sw) || 32);
-    const sh = Math.max(1, Number(m.sh) || 32);
-    minTx = tileOf(sx);          maxTx = tileOf(sx + sw - 1);
-    minTy = tileOf(sy);          maxTy = tileOf(sy + sh - 1);
+function findNearestFreeTile({
+  startTx,
+  startTy,
+  monster,
+  tilesForMap,
+  heroTiles,
+  maxDepth = MONSTER_STACK_RESOLVE_DEPTH,
+}) {
+  if (maxDepth <= 0) return null;
+
+  const queue = [{ tx: startTx, ty: startTy, depth: 0 }];
+  const visited = new Set([tileKey(startTx, startTy)]);
+  const heroTileSet = heroTiles instanceof Set ? heroTiles : new Set();
+
+  while (queue.length) {
+    const node = queue.shift();
+    if (node.depth >= maxDepth) continue;
+
+    for (const step of CARDINAL_STEPS) {
+      const nx = node.tx + step.dx;
+      const ny = node.ty + step.dy;
+      if (!isTileInsideSpawn(nx, ny, monster)) continue;
+
+      const key = tileKey(nx, ny);
+      if (visited.has(key)) continue;
+      visited.add(key);
+
+      const blockedByHero = heroTileSet.has(key);
+      const occupantSet = tilesForMap.get(key);
+      const blockedByMonster = occupantSet && occupantSet.size > 0;
+
+      if (!blockedByHero && !blockedByMonster) {
+        return { tx: nx, ty: ny };
+      }
+
+      if (blockedByHero) continue;
+
+      queue.push({ tx: nx, ty: ny, depth: node.depth + 1 });
+    }
   }
 
-  for (const d of tryDirs) {
-    const candX = mx + d.dx;
-    const candY = my + d.dy;
-    const inside =
-      candX >= minTx && candX <= maxTx &&
-      candY >= minTy && candY <= maxTy;
-    if (inside) return { nx: candX, ny: candY, moved: true };
+  return null;
+}
+
+function tilesOccupiedByOthers(set, monsterId) {
+  if (!set) return 0;
+  if (!set.size) return 0;
+  if (!set.has(monsterId)) return set.size;
+  if (set.size <= 1) return 0;
+  return set.size - 1;
+}
+
+function findBestStepToward({
+  mx,
+  my,
+  hx,
+  hy,
+  monster,
+  tilesForMap,
+  heroTiles,
+}) {
+  const heroTilesSet = heroTiles instanceof Set ? heroTiles : new Set();
+  const originKey = tileKey(mx, my);
+  const visited = new Set([originKey]);
+  const queue = [];
+  const currentDist = Math.abs(mx - hx) + Math.abs(my - hy);
+
+  const pushNode = (nx, ny, depth, firstStep) => {
+    if (depth > MONSTER_SEARCH_DEPTH) return;
+    if (!isTileInsideSpawn(nx, ny, monster)) return;
+    const key = tileKey(nx, ny);
+    if (visited.has(key)) return;
+    visited.add(key);
+    queue.push({
+      nx,
+      ny,
+      key,
+      depth,
+      firstStep,
+      dist: Math.abs(nx - hx) + Math.abs(ny - hy),
+    });
+  };
+
+  for (const step of CARDINAL_STEPS) {
+    const nx = mx + step.dx;
+    const ny = my + step.dy;
+    pushNode(nx, ny, 1, { nx, ny });
   }
-  return { nx: mx, ny: my, moved: false };
+
+  let best = null;
+
+  const scoreNode = (node) => {
+    const firstDist = Math.abs(node.firstStep.nx - hx) + Math.abs(node.firstStep.ny - hy);
+    const distDelta = firstDist - currentDist;
+    const backtrackPenalty = distDelta > 0 ? distDelta * MONSTER_STEP_BACKTRACK_PENALTY : 0;
+    return node.dist + (node.depth * 0.1) + backtrackPenalty;
+  };
+
+  while (queue.length) {
+    queue.sort((a, b) => {
+      const sa = scoreNode(a);
+      const sb = scoreNode(b);
+      if (sa !== sb) return sa - sb;
+      if (a.dist !== b.dist) return a.dist - b.dist;
+      return a.depth - b.depth;
+    });
+
+    const node = queue.shift();
+    const destKey = node.key;
+    if (destKey === originKey) continue;
+
+    const blockedByHero = heroTilesSet.has(destKey);
+    const destSet = tilesForMap.get(destKey);
+    const blockedByMonster = tilesOccupiedByOthers(destSet, monster.id) > 0;
+
+    if (!blockedByHero && !blockedByMonster) {
+      const score = scoreNode(node);
+      const improves = !best || score < best.score;
+      const keepsDistanceReasonable = node.dist <= currentDist || currentDist <= 1;
+      if (improves && keepsDistanceReasonable) {
+        best = {
+          nx: node.firstStep.nx,
+          ny: node.firstStep.ny,
+          score,
+          dist: node.dist,
+          depth: node.depth,
+        };
+        if (node.depth === 1 && node.dist <= currentDist) break;
+      }
+    }
+
+    if (node.depth >= MONSTER_SEARCH_DEPTH) {
+      continue;
+    }
+
+    for (const step of CARDINAL_STEPS) {
+      const nx = node.nx + step.dx;
+      const ny = node.ny + step.dy;
+      pushNode(nx, ny, node.depth + 1, node.firstStep);
+    }
+  }
+
+  return best;
+}
+
+async function resolveTileStacks({
+  tilesForMap,
+  heroTiles,
+  monstersById,
+  now,
+  budget,
+  movedSet,
+}) {
+  if (budget <= 0) return 0;
+  const heroTileSet = heroTiles instanceof Set ? heroTiles : new Set();
+  let used = 0;
+
+  for (const [tileKeyStr, occupants] of Array.from(tilesForMap.entries())) {
+    if (used >= budget) break;
+    if (!occupants || occupants.size <= 1) continue;
+
+    const ids = Array.from(occupants);
+    // Keep the first occupant, try to move the rest away
+    for (let i = 1; i < ids.length && used < budget; i++) {
+      const monsterId = ids[i];
+      const monster = monstersById.get(monsterId);
+      if (!monster) continue;
+
+      const lastMove = _lastMoveAt.get(monsterId) || 0;
+      if (now - lastMove < MONSTER_STEP_MS) continue;
+
+      const [txStr, tyStr] = tileKeyStr.split(',');
+      const tx = Number(txStr);
+      const ty = Number(tyStr);
+      if (!Number.isFinite(tx) || !Number.isFinite(ty)) continue;
+
+      const escape = findNearestFreeTile({
+        startTx: tx,
+        startTy: ty,
+        monster,
+        tilesForMap,
+        heroTiles: heroTileSet,
+      });
+
+      if (!escape) continue;
+
+      const fromSet = tilesForMap.get(tileKeyStr);
+      if (fromSet) {
+        fromSet.delete(monsterId);
+        if (!fromSet.size) tilesForMap.delete(tileKeyStr);
+      }
+
+      const destKey = tileKey(escape.tx, escape.ty);
+      if (!tilesForMap.has(destKey)) tilesForMap.set(destKey, new Set());
+      tilesForMap.get(destKey).add(monsterId);
+
+      const px = centerOfTile(escape.tx);
+      const py = centerOfTile(escape.ty);
+      monster.x = px;
+      monster.y = py;
+      _livePos.set(monsterId, { x: px, y: py, mapKey: monster.map_key });
+      _lastMoveAt.set(monsterId, now);
+      movedSet.add(monsterId);
+
+      try { await updateMonsterPos(monsterId, px, py, now); } catch {}
+
+      if (global._sendToMap) {
+        try { global._sendToMap(monster.map_key, { type: 'monster_move', id: monsterId, x: px, y: py }); } catch {}
+      }
+
+      used++;
+      if (used >= budget) break;
+    }
+  }
+
+  return used;
 }
 
 // ======= DB =======
@@ -159,9 +401,25 @@ async function tick() {
       fetchAliveMonsters(),
       fetchAliveHeroesWithPos(),
     ]);
+
+    for (const m of monsters) {
+      const live = _livePos.get(m.id);
+      if (!live) continue;
+      if (Number.isFinite(live.x)) m.x = live.x;
+      if (Number.isFinite(live.y)) m.y = live.y;
+      if (live.mapKey !== undefined && live.mapKey !== null) m.map_key = live.mapKey;
+    }
+
+    if (_livePos.size) {
+      const aliveIds = new Set(monsters.map(m => m.id));
+      for (const id of _livePos.keys()) {
+        if (!aliveIds.has(id)) _livePos.delete(id);
+      }
+    }
     if (!monsters.length || !heroes.length) { running = false; return; }
 
-    const slice = monsters.slice(0, MONSTER_MAX_PER_TICK);
+    const monsterTilesByMap = buildMonsterTileMap(monsters);
+    const heroTilesByMap = buildHeroTileSet(heroes);
 
     const heroesByMap = new Map();
     for (const h of heroes) {
@@ -170,10 +428,35 @@ async function tick() {
     }
 
     const now = Date.now();
+    const monstersById = new Map(monsters.map(m => [m.id, m]));
+    const movedThisTick = new Set();
+    let movesUsed = 0;
 
-    for (const m of slice) {
+    for (const [mapKeyStr, tilesForMap] of monsterTilesByMap.entries()) {
+      if (movesUsed >= MONSTER_MAX_PER_TICK) break;
+      const heroTilesForMap = heroTilesByMap.get(mapKeyStr) || new Set();
+      movesUsed += await resolveTileStacks({
+        tilesForMap,
+        heroTiles: heroTilesForMap,
+        monstersById,
+        now,
+        budget: MONSTER_MAX_PER_TICK - movesUsed,
+        movedSet: movedThisTick,
+      });
+    }
+
+    for (const m of monsters) {
+      const alreadyMoved = movedThisTick.has(m.id);
       const hs = heroesByMap.get(m.map_key);
       if (!hs || !hs.length) continue;
+
+      const mapKeyStr = m.map_key == null ? '__null__' : String(m.map_key);
+      let tilesForMap = monsterTilesByMap.get(mapKeyStr);
+      if (!tilesForMap) {
+        tilesForMap = new Map();
+        monsterTilesByMap.set(mapKeyStr, tilesForMap);
+      }
+      const heroTilesForMap = heroTilesByMap.get(mapKeyStr) || new Set();
 
       // Quantiza 1x: centraliza no tile
       if (!_wasQuantized.has(m.id)) {
@@ -184,6 +467,7 @@ async function tick() {
           m.x = cx; m.y = cy;
         }
         _wasQuantized.add(m.id);
+        _livePos.set(m.id, { x: m.x, y: m.y, mapKey: m.map_key });
       }
 
       // Alvo mais próximo (aplica gate se ligado; senão, considera todos)
@@ -191,6 +475,13 @@ async function tick() {
       let bestD = Infinity;
 
       const mx = tileOf(m.x), my = tileOf(m.y);
+      const currentTileKey = tileKey(mx, my);
+      if (!tilesForMap.has(currentTileKey)) {
+        tilesForMap.set(currentTileKey, new Set([m.id]));
+      } else {
+        const set = tilesForMap.get(currentTileKey);
+        if (!set.has(m.id)) set.add(m.id);
+      }
 
       // 1) tenta dentro do spawn
       for (const h of hs) {
@@ -215,15 +506,40 @@ async function tick() {
       const adjacent = isAdjacent4Tiles(mx, my, hx, hy);
 
       // 1) mover se não adjacente
-      if (!adjacent) {
+      if (!adjacent && !alreadyMoved) {
         const lastMove = _lastMoveAt.get(m.id) || 0;
-        if (now - lastMove >= MONSTER_STEP_MS) {
-          const step = nextTileToward(mx, my, hx, hy, m);
-          if (step.moved) {
-            const px = centerOfTile(step.nx);
-            const py = centerOfTile(step.ny);
+        const canMove = now - lastMove >= MONSTER_STEP_MS && movesUsed < MONSTER_MAX_PER_TICK;
+        if (canMove) {
+          const fromKey = tileKey(mx, my);
+          const bestStep = findBestStepToward({
+            mx,
+            my,
+            hx,
+            hy,
+            monster: m,
+            tilesForMap,
+            heroTiles: heroTilesForMap,
+          });
+
+          if (bestStep) {
+            const destKey = tileKey(bestStep.nx, bestStep.ny);
+
+            let fromSet = tilesForMap.get(fromKey);
+            if (fromSet) {
+              fromSet.delete(m.id);
+              if (!fromSet.size) tilesForMap.delete(fromKey);
+            }
+
+            if (!tilesForMap.has(destKey)) tilesForMap.set(destKey, new Set());
+            tilesForMap.get(destKey).add(m.id);
+
+            const px = centerOfTile(bestStep.nx);
+            const py = centerOfTile(bestStep.ny);
             m.x = px; m.y = py;
+            _livePos.set(m.id, { x: px, y: py, mapKey: m.map_key });
             _lastMoveAt.set(m.id, now);
+            movedThisTick.add(m.id);
+            movesUsed++;
             await updateMonsterPos(m.id, px, py, now);
 
             if (global._sendToMap) {
@@ -234,6 +550,8 @@ async function tick() {
           }
         }
         continue; // não ataca enquanto não estiver ao lado
+      } else if (!adjacent) {
+        continue;
       }
 
       // 2) adjacente → tentar bater (cooldown)

--- a/server/respawn/worker.js
+++ b/server/respawn/worker.js
@@ -12,6 +12,104 @@ const { broadcast } = require('../ws/bus');
 
 // Mundo em pixels (o cliente usa 32px por tile)
 const TILE = 32;
+const RESPAWN_EXTRA_RADIUS = Number(process.env.RESPAWN_TILE_SEARCH_RADIUS || 6);
+const RESPAWN_RETRY_DELAY_MS = Number(process.env.RESPAWN_RETRY_DELAY_MS || 1000);
+
+function tileOf(v) {
+  return Math.floor(Number(v || 0) / TILE);
+}
+
+function centerOfTile(t) {
+  return (t * TILE) + TILE / 2;
+}
+
+function tileKey(tx, ty) {
+  return `${tx},${ty}`;
+}
+
+function spawnTileBounds(spawn) {
+  const x0 = Number(spawn.x) || 0;
+  const y0 = Number(spawn.y) || 0;
+  const w  = Math.max(TILE, Number(spawn.w) || 0);
+  const h  = Math.max(TILE, Number(spawn.h) || 0);
+
+  const minTx = tileOf(x0);
+  const minTy = tileOf(y0);
+  const maxTx = tileOf(x0 + w - 1);
+  const maxTy = tileOf(y0 + h - 1);
+
+  return { minTx, maxTx, minTy, maxTy };
+}
+
+function pickTilesInSpawn(spawn) {
+  const { minTx, maxTx, minTy, maxTy } = spawnTileBounds(spawn);
+
+  const tiles = [];
+  for (let tx = minTx; tx <= maxTx; tx++) {
+    for (let ty = minTy; ty <= maxTy; ty++) {
+      tiles.push({ tx, ty });
+    }
+  }
+  return tiles;
+}
+
+function shuffleInPlace(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getOccupiedTilesForMap(cache, mapKey) {
+  const key = mapKey == null ? '__null__' : String(mapKey);
+  if (!cache.has(key)) cache.set(key, new Set());
+  return cache.get(key);
+}
+
+function markTileOccupied(cache, mapKey, tx, ty) {
+  const set = getOccupiedTilesForMap(cache, mapKey);
+  set.add(tileKey(tx, ty));
+}
+
+function findFreeTileAroundSpawn(spawn, mapKey, occupiedCache) {
+  const occ = getOccupiedTilesForMap(occupiedCache, mapKey);
+  const bounds = spawnTileBounds(spawn);
+  const { minTx, maxTx, minTy, maxTy } = bounds;
+
+  for (let radius = 1; radius <= RESPAWN_EXTRA_RADIUS; radius++) {
+    const minX = minTx - radius;
+    const maxX = maxTx + radius;
+    const minY = minTy - radius;
+    const maxY = maxTy + radius;
+
+    for (let tx = minX; tx <= maxX; tx++) {
+      for (let ty = minY; ty <= maxY; ty++) {
+        const onPerimeter = tx === minX || tx === maxX || ty === minY || ty === maxY;
+        if (!onPerimeter) continue;
+        const key = tileKey(tx, ty);
+        if (occ.has(key)) continue;
+        occ.add(key);
+        return { x: centerOfTile(tx), y: centerOfTile(ty), tx, ty };
+      }
+    }
+  }
+  return null;
+}
+
+function reserveTileForSpawn(spawn, mapKey, occupiedCache) {
+  const tiles = shuffleInPlace(pickTilesInSpawn(spawn));
+  const occ = getOccupiedTilesForMap(occupiedCache, mapKey);
+
+  for (const t of tiles) {
+    const key = tileKey(t.tx, t.ty);
+    if (occ.has(key)) continue;
+    occ.add(key);
+    return { x: centerOfTile(t.tx), y: centerOfTile(t.ty), tx: t.tx, ty: t.ty };
+  }
+
+  return findFreeTileAroundSpawn(spawn, mapKey, occupiedCache);
+}
 
 function pickPosInSpawnRect(spawn) {
   // x,y do Tiled já vêm em pixels (top-left). w,h podem ser 0/NULL → usar TILE como fallback.
@@ -64,6 +162,22 @@ async function respawnTick({ all, run }) {
 
   if (DEBUG) console.log('[respawn] due count =', due.length);
 
+  const occupiedByMap = new Map();
+  if (due.length) {
+    const aliveTiles = await all(`
+      SELECT map_key, x, y
+        FROM monster_instances
+       WHERE state = 'ALIVE'
+    `);
+
+    for (const row of aliveTiles) {
+      const tx = tileOf(row.x);
+      const ty = tileOf(row.y);
+      if (!Number.isFinite(tx) || !Number.isFinite(ty)) continue;
+      markTileOccupied(occupiedByMap, row.map_key, tx, ty);
+    }
+  }
+
   for (const r of due) {
     // HP que vamos usar pra voltar:
     const hpFull =
@@ -72,10 +186,40 @@ async function respawnTick({ all, run }) {
       : 1;
 
     // Escolhe uma posição dentro da área do spawn (em pixels)
-    const pos = pickPosInSpawnRect(r);
+    const mapKey = r.map_key == null ? '__null__' : String(r.map_key);
+    let chosen = reserveTileForSpawn(r, mapKey, occupiedByMap);
+    if (!chosen) {
+      const occ = getOccupiedTilesForMap(occupiedByMap, mapKey);
+      for (let attempt = 0; attempt < 8 && !chosen; attempt++) {
+        const fallbackPos = pickPosInSpawnRect(r);
+        const tx = tileOf(fallbackPos.x);
+        const ty = tileOf(fallbackPos.y);
+        if (!Number.isFinite(tx) || !Number.isFinite(ty)) continue;
+        const key = tileKey(tx, ty);
+        if (occ.has(key)) continue;
+        occ.add(key);
+        chosen = {
+          x: centerOfTile(tx),
+          y: centerOfTile(ty),
+          tx,
+          ty,
+        };
+      }
+    }
 
-    const px = Math.round(pos.x);
-    const py = Math.round(pos.y);
+    if (!chosen) {
+      await run(
+        `UPDATE monster_instances
+            SET respawn_at = NOW() + ($2 || ' milliseconds')::interval
+          WHERE id = $1`,
+        [r.id, String(Math.max(250, RESPAWN_RETRY_DELAY_MS))]
+      );
+      if (DEBUG) console.log('[respawn] no free tile, delaying instance', r.id);
+      continue;
+    }
+
+    const px = Math.round(chosen.x);
+    const py = Math.round(chosen.y);
 
     await run(
       `UPDATE monster_instances
@@ -114,8 +258,8 @@ async function respawnTick({ all, run }) {
         spawnId: r.spawn_id,      // <-- opcional
         hp: hpFull,
         maxHp: hpFull,
-        x: pos.x,
-        y: pos.y,
+        x: px,
+        y: py,
       };
       if (DEBUG) console.log('[respawn] broadcast', payload);
       broadcast(payload);


### PR DESCRIPTION
## Summary
- expand the simple AI step picker to score nearby tiles, avoid occupied squares, and keep monsters from overlapping while chasing
- reserve spawn tiles per map, search for nearby free squares, and delay revives when the spawn is full so respawns do not stack on one tile
- keep an in-memory cache of live monster positions so occupancy checks persist between ticks even when database writes are throttled
- add a stack-dispersion pass before each chase tick and drop the slice limit so every monster can relocate to a free tile before pathfinding
- extend the legacy ai-mobs loop to maintain per-map tile occupancy, disperse stacked mobs ahead of movement, and reject hero-occupied or monster-occupied squares when choosing chase steps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1682558248327a4fb8f95f037a027