### PR TITLE
Fix monster death animation orientation

### DIFF
--- a/client/js/play.js
+++ b/client/js/play.js
@@ -767,9 +767,46 @@ function handleServerMonsterDead(msg = {}) {
 
   const state = getOrCreateServerMonsterState(id);
   const sprite = state.sprite || window.GameScene?.getMobByInstanceId?.(id) || null;
+  const msgX = Number(msg.x);
+  const msgY = Number(msg.y);
+
+  if (sprite && sprite._serverMove) {
+    const mv = sprite._serverMove;
+    const toX = Number.isFinite(mv?.toX) ? mv.toX : null;
+    const toY = Number.isFinite(mv?.toY) ? mv.toY : null;
+    if (Number.isFinite(toX)) sprite.x = toX;
+    if (Number.isFinite(toY)) sprite.y = toY;
+  }
+
   state.dead = true;
   state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
   state.isMoving = false;
+  const finalX = Number.isFinite(msgX)
+    ? msgX
+    : Number.isFinite(sprite?.x)
+      ? sprite.x
+      : Number.isFinite(state.renderX)
+        ? state.renderX
+        : state.x;
+  const finalY = Number.isFinite(msgY)
+    ? msgY
+    : Number.isFinite(sprite?.y)
+      ? sprite.y
+      : Number.isFinite(state.renderY)
+        ? state.renderY
+        : state.y;
+
+  if (Number.isFinite(finalX)) {
+    state.x = finalX;
+    state.renderX = finalX;
+    if (sprite) sprite.x = finalX;
+  }
+  if (Number.isFinite(finalY)) {
+    state.y = finalY;
+    state.renderY = finalY;
+    if (sprite) sprite.y = finalY;
+  }
+
   const face = sprite?.face || state.face || 'south';
   setMonsterAction(state, sprite, 'dead', { face });
   state.face = face;
@@ -781,6 +818,7 @@ function handleServerMonsterDead(msg = {}) {
     sprite._animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
     sprite._animFrozen = false;
     sprite._animFrozenFrame = 0;
+    sprite._animIsMoving = false;
   }
   SERVER_MONSTER_STATE.set(id, state);
   UNBOUND_SERVER_MONSTERS.delete(id);
@@ -1099,13 +1137,15 @@ function inferMetaFromImage(img, rawKey) {
   }
   const cols = Math.max(1, Math.floor(img.naturalWidth / fw));
   const rows = Math.max(1, Math.floor(img.naturalHeight / fh));
-  const directionalSeq = (cols >= 4)
-    ? {
-        south: [0],
-        west: [1],
-        east: [2],
-        north: [3],
-      }
+  const directionalRows = (rows >= 5)
+    ? { south: 1, west: 2, east: 3, north: 4 }
+    : (rows >= 4)
+      ? { south: 0, west: 1, east: 2, north: 3 }
+      : null;
+  const baseDirRow = directionalRows ? directionalRows.south : 0;
+  const deadRowIndex = rows >= 5 ? Math.min(rows - 1, 4) : rows - 1;
+  const attackRows = rows >= 10
+    ? { west: 5, east: 6, south: 7, north: 8 }
     : null;
   return {
     key: String(rawKey || '').trim(),
@@ -1119,36 +1159,37 @@ function inferMetaFromImage(img, rawKey) {
         fps: 6,
         frames: Math.min(4, cols),
         startCol: 0,
-        rowByDir: (rows >= 5) ? { south: 1, west: 2, east: 3, north: 4 }
-                              : (rows >= 4) ? { south: 0, west: 1, east: 2, north: 3 } : null,
-        row: 0,
+        rowByDir: directionalRows || undefined,
+        row: baseDirRow,
         loop: true
       },
       idle: (rows >= 1)
         ? {
-            fps: 3,
-            frames: Math.min(4, cols),
-            row: 0,
-            loop: true,
-            seqByDir: directionalSeq || undefined,
+            fps: 2,
+            frames: 1,
+            row: baseDirRow,
+            loop: false,
+            rowByDir: directionalRows || undefined,
+            startCol: 0,
           }
         : null,
-      dead: (rows >= 6)
+      dead: (rows >= 2)
         ? {
             fps: 4,
             frames: Math.min(4, cols),
-            row: 5,
+            row: Math.max(0, deadRowIndex),
             loop: false,
-            seqByDir: directionalSeq || undefined,
+            startCol: 0,
           }
         : null,
       attack: (rows >= 10)
         ? {
             fps: 10,
             frames: Math.min(4, cols),
-            row: 6,
+            row: attackRows?.south ?? 5,
             loop: false,
-            rowByDir: { west: 6, east: 7, south: 8, north: 9 },
+            rowByDir: attackRows || undefined,
+            startCol: 0,
           }
         : null,
     }


### PR DESCRIPTION
## Summary
- ensure monster sprites snap to their final position when a death update arrives and remain visible until respawn
- adjust inferred monster animation metadata so idle uses the current facing row and the death row matches the 5th line of Tibia-style spritesheets

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1e85d9bf0832783668b41456c11df