### PR TITLE
Ensure monsters use YAML sprite metadata and smooth server movement

### DIFF
--- a/client/js/play.js
+++ b/client/js/play.js
@@ -295,7 +295,6 @@ let _serverMonsterRetryScheduled = false;
 const SERVER_MONSTER_STEP_MS = 180;
 const SERVER_MONSTER_MIN_TWEEN_MS = 60;
 const SERVER_MONSTER_MAX_TWEEN_MS = 260;
-const SERVER_MONSTER_TELEPORT_THRESHOLD = TILE * 4; // deslocamentos maiores tratam como teleporte
 const SERVER_MONSTER_BASE_SPEED = TILE / (SERVER_MONSTER_STEP_MS / 1000);
 const SERVER_MONSTER_IDLE_ANIM = 0.8;
 const SERVER_MONSTER_MIN_ANIM = 0.65;
@@ -435,7 +434,6 @@ function ensureServerMonsterSprite(msg = {}) {
   if (msg.mapKey != null) state.mapKey = String(msg.mapKey);
   if (msg.spawnId != null && Number.isFinite(Number(msg.spawnId))) state.spawnId = Number(msg.spawnId);
   if (msg.monsterKey) state.monsterKey = String(msg.monsterKey);
-  state.dead = false;
 
   let sprite = window.GameScene?.getMobByInstanceId?.(id) || state.sprite || null;
 
@@ -524,10 +522,12 @@ function setMonsterAction(state, sprite, action, { until = null, face = null } =
   }
 }
 
-function applyServerPosition(id, sprite, x, y) {
+function applyServerPosition(id, sprite, x, y, opts = {}) {
   if (!Number.isFinite(x) || !Number.isFinite(y)) return;
   const state = getOrCreateServerMonsterState(id);
   const now = performance.now();
+  const options = (opts && typeof opts === 'object') ? opts : {};
+  const forceTeleport = options.forceTeleport === true;
 
   const current = sprite ? currentSpriteRenderPos(sprite, now) : {
     x: Number.isFinite(state.renderX) ? state.renderX : (Number.isFinite(state.x) ? state.x : x),
@@ -549,11 +549,11 @@ function applyServerPosition(id, sprite, x, y) {
     if (tweenDur > cap) tweenDur = cap;
   }
 
-  const shouldTeleport = !Number.isFinite(dist) || dist < 1 || dist > SERVER_MONSTER_TELEPORT_THRESHOLD;
+  const shouldTeleport = forceTeleport || !Number.isFinite(dist) || dist < 1;
 
   let animMultiplier = SERVER_MONSTER_IDLE_ANIM;
   let isMoving = false;
-  let face = state.face || (sprite?.face) || 'south';
+  let face = (typeof options.face === 'string' && options.face) || state.face || (sprite?.face) || 'south';
   if (!shouldTeleport && tweenDur > 0 && dist >= 1) {
     const pxPerSec = dist / (tweenDur / 1000);
     if (Number.isFinite(pxPerSec) && SERVER_MONSTER_BASE_SPEED > 0) {
@@ -701,7 +701,7 @@ function retryBindPendingServerMonsters() {
     if (!sprite) continue;
 
     if (Number.isFinite(state.x) && Number.isFinite(state.y)) {
-      applyServerPosition(id, sprite, state.x, state.y);
+      applyServerPosition(id, sprite, state.x, state.y, { face: state.face });
     } else {
       if (!Number.isFinite(state.animSpeedMultiplier)) state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
       sprite._animSpeedMultiplier = state.animSpeedMultiplier;
@@ -733,14 +733,18 @@ function handleServerMonsterRespawn(msg = {}) {
   if (!id) return;
 
   const sprite = ensureServerMonsterSprite(msg);
+  const state = getOrCreateServerMonsterState(id);
+  state.dead = false;
 
   const x = Number(msg.x);
   const y = Number(msg.y);
   if (sprite && Number.isFinite(x) && Number.isFinite(y)) {
-    applyServerPosition(id, sprite, x, y);
+    applyServerPosition(id, sprite, x, y, { forceTeleport: true, face: state.face });
   } else if (Number.isFinite(x) && Number.isFinite(y)) {
-    applyServerPosition(id, null, x, y);
+    applyServerPosition(id, null, x, y, { forceTeleport: true, face: state.face });
   }
+
+  SERVER_MONSTER_STATE.set(id, state);
 }
 
 function handleServerMonsterMove(msg = {}) {
@@ -752,11 +756,25 @@ function handleServerMonsterMove(msg = {}) {
   const y = Number(msg.y);
   if (!Number.isFinite(x) || !Number.isFinite(y)) return;
 
+  const state = getOrCreateServerMonsterState(id);
+  if (state.dead) {
+    if (Number.isFinite(x)) {
+      state.x = x;
+      state.renderX = x;
+    }
+    if (Number.isFinite(y)) {
+      state.y = y;
+      state.renderY = y;
+    }
+    SERVER_MONSTER_STATE.set(id, state);
+    return;
+  }
+
   const sprite = ensureServerMonsterSprite(msg);
   if (sprite) {
-    applyServerPosition(id, sprite, x, y);
+    applyServerPosition(id, sprite, x, y, { face: state.face });
   } else {
-    applyServerPosition(id, null, x, y);
+    applyServerPosition(id, null, x, y, { face: state.face });
   }
 }
 
@@ -767,9 +785,46 @@ function handleServerMonsterDead(msg = {}) {
 
   const state = getOrCreateServerMonsterState(id);
   const sprite = state.sprite || window.GameScene?.getMobByInstanceId?.(id) || null;
+  const msgX = Number(msg.x);
+  const msgY = Number(msg.y);
+
+  if (sprite && sprite._serverMove) {
+    const mv = sprite._serverMove;
+    const toX = Number.isFinite(mv?.toX) ? mv.toX : null;
+    const toY = Number.isFinite(mv?.toY) ? mv.toY : null;
+    if (Number.isFinite(toX)) sprite.x = toX;
+    if (Number.isFinite(toY)) sprite.y = toY;
+  }
+
   state.dead = true;
   state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
   state.isMoving = false;
+  const finalX = Number.isFinite(msgX)
+    ? msgX
+    : Number.isFinite(sprite?.x)
+      ? sprite.x
+      : Number.isFinite(state.renderX)
+        ? state.renderX
+        : state.x;
+  const finalY = Number.isFinite(msgY)
+    ? msgY
+    : Number.isFinite(sprite?.y)
+      ? sprite.y
+      : Number.isFinite(state.renderY)
+        ? state.renderY
+        : state.y;
+
+  if (Number.isFinite(finalX)) {
+    state.x = finalX;
+    state.renderX = finalX;
+    if (sprite) sprite.x = finalX;
+  }
+  if (Number.isFinite(finalY)) {
+    state.y = finalY;
+    state.renderY = finalY;
+    if (sprite) sprite.y = finalY;
+  }
+
   const face = sprite?.face || state.face || 'south';
   setMonsterAction(state, sprite, 'dead', { face });
   state.face = face;
@@ -781,6 +836,7 @@ function handleServerMonsterDead(msg = {}) {
     sprite._animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
     sprite._animFrozen = false;
     sprite._animFrozenFrame = 0;
+    sprite._animIsMoving = false;
   }
   SERVER_MONSTER_STATE.set(id, state);
   UNBOUND_SERVER_MONSTERS.delete(id);
@@ -1099,13 +1155,15 @@ function inferMetaFromImage(img, rawKey) {
   }
   const cols = Math.max(1, Math.floor(img.naturalWidth / fw));
   const rows = Math.max(1, Math.floor(img.naturalHeight / fh));
-  const directionalSeq = (cols >= 4)
-    ? {
-        south: [0],
-        west: [1],
-        east: [2],
-        north: [3],
-      }
+  const directionalRows = (rows >= 5)
+    ? { south: 1, west: 2, east: 3, north: 4 }
+    : (rows >= 4)
+      ? { south: 0, west: 1, east: 2, north: 3 }
+      : null;
+  const baseDirRow = directionalRows ? directionalRows.south : 0;
+  const deadRowIndex = rows >= 5 ? Math.min(rows - 1, 4) : rows - 1;
+  const attackRows = rows >= 10
+    ? { west: 5, east: 6, south: 7, north: 8 }
     : null;
   return {
     key: String(rawKey || '').trim(),
@@ -1119,36 +1177,37 @@ function inferMetaFromImage(img, rawKey) {
         fps: 6,
         frames: Math.min(4, cols),
         startCol: 0,
-        rowByDir: (rows >= 5) ? { south: 1, west: 2, east: 3, north: 4 }
-                              : (rows >= 4) ? { south: 0, west: 1, east: 2, north: 3 } : null,
-        row: 0,
+        rowByDir: directionalRows || undefined,
+        row: baseDirRow,
         loop: true
       },
       idle: (rows >= 1)
         ? {
-            fps: 3,
-            frames: Math.min(4, cols),
-            row: 0,
-            loop: true,
-            seqByDir: directionalSeq || undefined,
+            fps: 2,
+            frames: 1,
+            row: baseDirRow,
+            loop: false,
+            rowByDir: directionalRows || undefined,
+            startCol: 0,
           }
         : null,
-      dead: (rows >= 6)
+      dead: (rows >= 2)
         ? {
             fps: 4,
             frames: Math.min(4, cols),
-            row: 5,
+            row: Math.max(0, deadRowIndex),
             loop: false,
-            seqByDir: directionalSeq || undefined,
+            startCol: 0,
           }
         : null,
       attack: (rows >= 10)
         ? {
             fps: 10,
             frames: Math.min(4, cols),
-            row: 6,
+            row: attackRows?.south ?? 5,
             loop: false,
-            rowByDir: { west: 6, east: 7, south: 8, north: 9 },
+            rowByDir: attackRows || undefined,
+            startCol: 0,
           }
         : null,
     }

--- a/server/index.js
+++ b/server/index.js
@@ -40,6 +40,8 @@ const gachaRoutes = require('./gacha/routes');
 const catalogRoutes = require('./routes/catalog');
 const skillsRoutes = require('./skills/routes');
 
+const { loadSpriteMetaFromDisk } = require('./utils/loadSpriteMetaFromDisk');
+
 // Loot (pickup + listar loots)
 const lootRoutes = require('./routes/loot'); // <<-- novo
 
@@ -561,18 +563,70 @@ app.get('/api/assets/items', async (req, res) => {
 app.get('/api/assets/sprites', async (req, res) => {
   try {
     const cacheKey = 'assets:sprites';
-    
+
     // Try cache first, then query database if needed
     let data;
     const cachedEntry = httpCache.get(cacheKey);
-    
+
     if (cachedEntry) {
       data = cachedEntry.value;
     } else {
-      const rows = await all('SELECT key, kind, "dataJSON" FROM sprites_master ORDER BY key');
-      data = rows.map(r => ({ key: r.key, kind: r.kind, data: r.dataJSON || {} }));
+      const rows = await all('SELECT key, kind, "dataJSON" FROM sprites_master ORDER BY key').catch(() => []);
+      const dbEntries = Array.isArray(rows)
+        ? rows.map((r) => {
+            const raw = r.dataJSON ?? r.datajson ?? null;
+            let parsed = raw;
+            if (typeof parsed === 'string') {
+              try { parsed = JSON.parse(parsed); } catch { parsed = {}; }
+            }
+            if (!parsed || typeof parsed !== 'object') parsed = {};
+            return {
+              key: String(r.key),
+              kind: (r.kind && String(r.kind)) || null,
+              data: parsed,
+            };
+          })
+        : [];
+
+      const diskEntries = loadSpriteMetaFromDisk();
+
+      if (!dbEntries.length && Array.isArray(diskEntries) && diskEntries.length) {
+        data = diskEntries.map((entry) => ({
+          key: String(entry.key),
+          kind: (entry.kind && String(entry.kind)) || 'sprite',
+          data: entry.data || {},
+        }));
+      } else if (dbEntries.length) {
+        const merged = new Map();
+
+        if (Array.isArray(diskEntries)) {
+          for (const entry of diskEntries) {
+            if (!entry || !entry.key) continue;
+            const key = String(entry.key);
+            merged.set(key, {
+              key,
+              kind: (entry.kind && String(entry.kind)) || 'sprite',
+              data: entry.data || {},
+            });
+          }
+        }
+
+        for (const entry of dbEntries) {
+          if (!entry || !entry.key) continue;
+          const key = String(entry.key);
+          merged.set(key, {
+            key,
+            kind: entry.kind || (merged.get(key)?.kind) || 'sprite',
+            data: entry.data,
+          });
+        }
+
+        data = Array.from(merged.values());
+      } else {
+        data = [];
+      }
     }
-    
+
     // Handle ETag/304 response
     httpCache.handleEtagResponse(req, res, cacheKey, data, ASSETS_CACHE_TTL_MS);
   } catch (err) {

--- a/server/utils/loadSpriteMetaFromDisk.js
+++ b/server/utils/loadSpriteMetaFromDisk.js
@@ -1,0 +1,121 @@
+// server/utils/loadSpriteMetaFromDisk.js
+// Helper to load sprite metadata directly from YAML files on disk.
+
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+
+const SPRITE_BASE_PATHS = [
+  path.resolve(process.cwd(), 'data/sprites'),
+  path.resolve(process.cwd(), 'server/content/data/sprites'),
+  path.resolve(process.cwd(), 'content/data/sprites'),
+];
+
+function firstExisting(paths) {
+  for (const p of paths) {
+    if (p && fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+function listYamlFilesRecursive(dir) {
+  const out = [];
+  if (!dir || !fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = fs.statSync(full);
+    if (st.isDirectory()) out.push(...listYamlFilesRecursive(full));
+    else if (entry.toLowerCase().endsWith('.yml') || entry.toLowerCase().endsWith('.yaml')) out.push(full);
+  }
+  return out;
+}
+
+function inferKindFromPath(filePath, data) {
+  if (data && typeof data.kind === 'string' && data.kind.trim()) {
+    return data.kind.trim();
+  }
+  const fp = String(filePath || '').replace(/\\/g, '/').toLowerCase();
+  if (fp.includes('/monsters/')) return 'monster';
+  if (fp.includes('/characters/')) return 'character';
+  return 'sprite';
+}
+
+function normalizeKey(rawKey, fallbackFile) {
+  if (rawKey && String(rawKey).trim()) return String(rawKey).trim();
+  if (!fallbackFile) return null;
+  const base = path.basename(fallbackFile).replace(/\.(yml|yaml)$/i, '');
+  return base;
+}
+
+function loadFromIndex(baseDir) {
+  const idx = firstExisting([
+    path.join(baseDir, 'index.yml'),
+    path.join(baseDir, 'index.yaml'),
+  ]);
+  if (!idx) return null;
+  try {
+    const parsed = YAML.parse(fs.readFileSync(idx, 'utf8'));
+    const entries = Object.entries((parsed && parsed.sprites) || {});
+    return entries.map(([key, rel]) => ({
+      key: String(key),
+      file: path.join(baseDir, rel),
+    }));
+  } catch (err) {
+    console.warn('[sprites] falha ao ler index YAML:', idx, err?.message);
+    return null;
+  }
+}
+
+function uniqueByKey(entries) {
+  const map = new Map();
+  for (const ent of entries) {
+    if (!ent || !ent.key) continue;
+    const k = String(ent.key);
+    if (!map.has(k)) map.set(k, ent);
+  }
+  return Array.from(map.values());
+}
+
+function loadSpriteMetaFromBase(baseDir) {
+  if (!baseDir || !fs.existsSync(baseDir)) return [];
+  const entries = loadFromIndex(baseDir) || listYamlFilesRecursive(baseDir).map((file) => ({ key: null, file }));
+  const out = [];
+  for (const ent of entries) {
+    const file = ent.file;
+    if (!file || !fs.existsSync(file)) continue;
+    let data;
+    try {
+      const raw = fs.readFileSync(file, 'utf8');
+      data = YAML.parse(raw);
+    } catch (err) {
+      console.warn('[sprites] falha ao ler YAML:', file, err?.message);
+      continue;
+    }
+    if (!data || typeof data !== 'object') continue;
+    const key = normalizeKey(data.key || ent.key, file);
+    if (!key) continue;
+    const kind = inferKindFromPath(file, data);
+    out.push({ key, kind, data });
+  }
+  return uniqueByKey(out);
+}
+
+function loadSpriteMetaFromDisk() {
+  const collected = [];
+  for (const base of SPRITE_BASE_PATHS) {
+    collected.push(...loadSpriteMetaFromBase(base));
+  }
+  const deduped = new Map();
+  for (const entry of collected) {
+    if (!entry || !entry.key) continue;
+    const key = String(entry.key);
+    if (!deduped.has(key)) {
+      deduped.set(key, entry);
+    }
+  }
+  return Array.from(deduped.values());
+}
+
+module.exports = {
+  loadSpriteMetaFromDisk,
+};


### PR DESCRIPTION
## Summary
- add a server-side fallback so /api/assets/sprites returns data/sprites YAML definitions when the database cache is empty
- expose a reusable helper for loading sprite metadata from disk
- adjust client monster tweening to preserve facing, animate long moves, and only force teleports on explicit respawns

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1e85d9bf0832783668b41456c11df