### PR TITLE
Restore repository to PR #62 state

### DIFF
--- a/client/js/play.js
+++ b/client/js/play.js
@@ -15,6 +15,7 @@ import { HeroState } from './state/hero-state.js';
 const QS = new URLSearchParams(location.search);
 const MAP_KEY = QS.get('map') || 'house';
 const TILE = 32;
+const playerVis = { w: 32, h: 32, img: null, heroKey: null, anchorX: 0.5, anchorY: 0.9 };
 // Desliga a IA local de mobs; posição deve vir do servidor
 const ENABLE_LOCAL_MOB_AI = false;
 
@@ -115,24 +116,25 @@ onMessage('hero_hit', (msg) => {
   const line = `[Dano] ${mobName} te acertou por ${amount} (HP: ${hpStr})`;
   if (window.Chat?.pushLog) window.Chat.pushLog(line); else console.log('[LOG]', line);
 
-  // Dano flutuante acima do monstro (se soubermos posição) — cai pro player se não tiver
-  if (window.HeroDamageUI && typeof window.HeroDamageUI.spawn === 'function') {
-    let x = Number(msg?.monster?.x), y = Number(msg?.monster?.y);
+  // Dano flutuante acima do herói atingido
+  if (window.HeroDamageUI) {
+    const spawn = typeof window.HeroDamageUI.spawn === 'function' ? window.HeroDamageUI.spawn : null;
+    const spawnAtHero = typeof window.HeroDamageUI.spawnAtHero === 'function' ? window.HeroDamageUI.spawnAtHero : null;
 
-    // Se só veio instanceId, tenta achar a sprite do mob ligado ao instanceId
-    if ((!Number.isFinite(x) || !Number.isFinite(y)) && msg.instanceId && window.GameScene?.getMobByInstanceId) {
-      const s = window.GameScene.getMobByInstanceId(String(msg.instanceId));
-      if (s) { x = s.x; y = s.y; }
+    let hx = null;
+    let hy = null;
+    const heroPos = getHeroWorldPosition(msg.heroId);
+    if (heroPos) { hx = heroPos.x; hy = heroPos.y; }
+
+    if ((!Number.isFinite(hx) || !Number.isFinite(hy)) && window.GameScene?.controller?.getPosition) {
+      const p = window.GameScene.controller.getPosition();
+      if (p && Number.isFinite(p.x) && Number.isFinite(p.y)) { hx = p.x; hy = p.y; }
     }
 
-    // Fallback: usa a posição do player
-    if (!Number.isFinite(x) || !Number.isFinite(y)) {
-      const p = window.GameScene?.controller?.getPosition?.();
-      if (p) { x = p.x; y = p.y - 16; }
-    }
-
-    if (Number.isFinite(x) && Number.isFinite(y)) {
-      window.HeroDamageUI.spawn({ x, y, amount, kind: 'from_mob' });
+    if (Number.isFinite(hx) && Number.isFinite(hy) && spawn) {
+      spawn({ x: hx, y: hy, amount, kind: 'from_mob' });
+    } else if (spawnAtHero) {
+      spawnAtHero(amount, 'from_mob', msg.heroId);
     }
   }
 
@@ -287,9 +289,10 @@ window.GameScene.onMonsterDead = (instanceId) => {
 };
 
 // ======= Server-driven monster state =======
-const SERVER_MONSTER_STATE = new Map(); // id -> { sprite, x, y, spawnId, monsterKey, mapKey, dead, renderX, renderY, animSpeedMultiplier, isMoving, blockKey, tileX, tileY, lastServerAt }
+const SERVER_MONSTER_STATE = new Map(); // id -> { sprite, x, y, spawnId, monsterKey, mapKey, dead, renderX, renderY, animSpeedMultiplier, isMoving, blockedTiles, lastServerAt }
 const UNBOUND_SERVER_MONSTERS = new Set(); // ids aguardando sprite
 const MONSTER_BLOCKED_TILES = new Map(); // "cx,cy" -> Set(instanceId)
+const HERO_BLOCK_STATE = { tiles: new Set(), lastX: null, lastY: null };
 let _serverMonsterRetryScheduled = false;
 
 const SERVER_MONSTER_STEP_MS = 150;
@@ -317,13 +320,12 @@ function getOrCreateServerMonsterState(id) {
       renderY: null,
       animSpeedMultiplier: SERVER_MONSTER_IDLE_ANIM,
       isMoving: false,
-      blockKey: null,
-      tileX: null,
-      tileY: null,
+      blockedTiles: new Set(),
       lastServerAt: null,
       face: 'south',
       action: 'idle',
       actionUntil: null,
+      meta: null,
     };
     SERVER_MONSTER_STATE.set(key, state);
   }
@@ -428,34 +430,177 @@ function monsterTileKey(cx, cy) {
   return `${cx | 0},${cy | 0}`;
 }
 
-function removeMonsterFromTile(state) {
-  if (!state || !state.blockKey) return;
-  const set = MONSTER_BLOCKED_TILES.get(state.blockKey);
-  if (set) {
-    set.delete(state.id);
-    if (!set.size) MONSTER_BLOCKED_TILES.delete(state.blockKey);
-  }
-  state.blockKey = null;
-  state.tileX = null;
-  state.tileY = null;
+function clearHeroBlocking() {
+  if (!HERO_BLOCK_STATE || !HERO_BLOCK_STATE.tiles) return;
+  if (!HERO_BLOCK_STATE.tiles.size) return;
+  HERO_BLOCK_STATE.tiles.clear();
+  HERO_BLOCK_STATE.lastX = null;
+  HERO_BLOCK_STATE.lastY = null;
 }
 
-function updateMonsterBlocking(state, cx, cy) {
-  if (!state) return;
-  removeMonsterFromTile(state);
-  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return;
-  const ix = Math.floor(cx);
-  const iy = Math.floor(cy);
-  const key = monsterTileKey(ix, iy);
-  let set = MONSTER_BLOCKED_TILES.get(key);
-  if (!set) {
-    set = new Set();
-    MONSTER_BLOCKED_TILES.set(key, set);
+function heroSpriteMeta() {
+  const frameW = Number.isFinite(playerVis?.w) && playerVis.w > 0 ? playerVis.w : TILE;
+  const frameH = Number.isFinite(playerVis?.h) && playerVis.h > 0 ? playerVis.h : TILE;
+  let anchorX = Number.isFinite(playerVis?.anchorX) ? playerVis.anchorX : 0.5;
+  let anchorY = Number.isFinite(playerVis?.anchorY) ? playerVis.anchorY : 0.9;
+  anchorX = Math.max(0, Math.min(1, anchorX));
+  anchorY = Math.max(0, Math.min(1, anchorY));
+  return { frameW, frameH, anchorX, anchorY };
+}
+
+function heroFootboxTiles(px, py) {
+  if (!Number.isFinite(px) || !Number.isFinite(py)) return [];
+  const { frameW, frameH, anchorX, anchorY } = heroSpriteMeta();
+
+  const spriteLeft = px - frameW * anchorX;
+  const spriteTop = py - frameH * anchorY;
+  const spriteBottom = spriteTop + frameH;
+
+  const footHeight = Math.max(TILE / 2, Math.min(TILE, frameH));
+  const tolerance = 2;
+  const rectHeight = footHeight + tolerance * 2;
+  const rectTop = spriteBottom - footHeight - tolerance;
+  const rectWidth = frameW + tolerance * 2;
+  const rectLeft = spriteLeft - tolerance;
+
+  const minCx = Math.floor(rectLeft / TILE);
+  const maxCx = Math.floor((rectLeft + rectWidth - 1) / TILE);
+  const minCy = Math.floor(rectTop / TILE);
+  const maxCy = Math.floor((rectTop + rectHeight - 1) / TILE);
+
+  if (!Number.isFinite(minCx) || !Number.isFinite(maxCx) || !Number.isFinite(minCy) || !Number.isFinite(maxCy)) {
+    return [];
   }
-  set.add(state.id);
-  state.blockKey = key;
-  state.tileX = ix;
-  state.tileY = iy;
+
+  const keys = [];
+  for (let cy = minCy; cy <= maxCy; cy++) {
+    for (let cx = minCx; cx <= maxCx; cx++) {
+      keys.push(monsterTileKey(cx, cy));
+    }
+  }
+  return keys;
+}
+
+function updateHeroBlocking(px, py) {
+  if (!HERO_BLOCK_STATE || !HERO_BLOCK_STATE.tiles) return;
+  if (!Number.isFinite(px) || !Number.isFinite(py)) {
+    clearHeroBlocking();
+    return;
+  }
+
+  const lastX = HERO_BLOCK_STATE.lastX;
+  const lastY = HERO_BLOCK_STATE.lastY;
+  if (Number.isFinite(lastX) && Number.isFinite(lastY)) {
+    const dx = Math.abs(px - lastX);
+    const dy = Math.abs(py - lastY);
+    if (dx < 0.1 && dy < 0.1) return;
+  }
+
+  const nextKeys = new Set(heroFootboxTiles(px, py));
+  const current = HERO_BLOCK_STATE.tiles;
+
+  let changed = false;
+  const removals = [];
+  for (const key of current) {
+    if (!nextKeys.has(key)) removals.push(key);
+  }
+  for (const key of removals) {
+    current.delete(key);
+    changed = true;
+  }
+
+  for (const key of nextKeys) {
+    if (!current.has(key)) {
+      current.add(key);
+      changed = true;
+    }
+  }
+
+  HERO_BLOCK_STATE.lastX = px;
+  HERO_BLOCK_STATE.lastY = py;
+  if (!changed) return;
+}
+
+function removeMonsterFromTile(state) {
+  if (!state) return;
+  if (!state.blockedTiles) state.blockedTiles = new Set();
+  if (state.blockedTiles.size === 0) return;
+  for (const key of state.blockedTiles) {
+    const set = MONSTER_BLOCKED_TILES.get(key);
+    if (!set) continue;
+    set.delete(state.id);
+    if (!set.size) MONSTER_BLOCKED_TILES.delete(key);
+  }
+  state.blockedTiles.clear();
+}
+
+function updateMonsterBlocking(state, worldX, worldY) {
+  if (!state) return;
+  if (!state.blockedTiles) state.blockedTiles = new Set();
+  removeMonsterFromTile(state);
+
+  const sprite = state.sprite || null;
+  const metaCandidate = sprite?.meta || state.meta || (state.monsterKey ? findMetaFor(state.monsterKey) : null) || null;
+  if (metaCandidate && !state.meta) state.meta = metaCandidate;
+  if (sprite && metaCandidate && !sprite.meta) sprite.meta = metaCandidate;
+
+  const meta = metaCandidate || {};
+  let frameW = Number(meta.frame?.width);
+  let frameH = Number(meta.frame?.height);
+  if (!Number.isFinite(frameW) || frameW <= 0) frameW = Number(sprite?.w) || TILE;
+  if (!Number.isFinite(frameH) || frameH <= 0) frameH = Number(sprite?.h) || TILE;
+  if (!Number.isFinite(frameW) || frameW <= 0) frameW = TILE;
+  if (!Number.isFinite(frameH) || frameH <= 0) frameH = TILE;
+
+  let anchorX = Number(meta.anchor?.x);
+  let anchorY = Number(meta.anchor?.y);
+  if (!Number.isFinite(anchorX)) anchorX = 0.5;
+  if (!Number.isFinite(anchorY)) anchorY = 0.9;
+  anchorX = Math.max(0, Math.min(1, anchorX));
+  anchorY = Math.max(0, Math.min(1, anchorY));
+
+  const px = Number.isFinite(worldX)
+    ? worldX
+    : (Number.isFinite(state.x)
+        ? state.x
+        : (Number.isFinite(sprite?.x) ? sprite.x : NaN));
+  const py = Number.isFinite(worldY)
+    ? worldY
+    : (Number.isFinite(state.y)
+        ? state.y
+        : (Number.isFinite(sprite?.y) ? sprite.y : NaN));
+  if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+
+  const spriteLeft = px - frameW * anchorX;
+  const spriteTop = py - frameH * anchorY;
+  const spriteBottom = spriteTop + frameH;
+
+  const footHeight = Math.max(TILE / 2, Math.min(TILE, frameH));
+  const tolerance = 2;
+  const rectHeight = footHeight + tolerance * 2;
+  const rectTop = spriteBottom - footHeight - tolerance;
+  const rectWidth = frameW + tolerance * 2;
+  const rectLeft = spriteLeft - tolerance;
+
+  const minCx = Math.floor(rectLeft / TILE);
+  const maxCx = Math.floor((rectLeft + rectWidth - 1) / TILE);
+  const minCy = Math.floor(rectTop / TILE);
+  const maxCy = Math.floor((rectTop + rectHeight - 1) / TILE);
+
+  if (!Number.isFinite(minCx) || !Number.isFinite(maxCx) || !Number.isFinite(minCy) || !Number.isFinite(maxCy)) return;
+
+  for (let cy = minCy; cy <= maxCy; cy++) {
+    for (let cx = minCx; cx <= maxCx; cx++) {
+      const key = monsterTileKey(cx, cy);
+      let set = MONSTER_BLOCKED_TILES.get(key);
+      if (!set) {
+        set = new Set();
+        MONSTER_BLOCKED_TILES.set(key, set);
+      }
+      set.add(state.id);
+      state.blockedTiles.add(key);
+    }
+  }
 }
 
 function clearMonsterBlocking(id) {
@@ -464,8 +609,10 @@ function clearMonsterBlocking(id) {
   removeMonsterFromTile(state);
 }
 
-function isTileBlockedByMonster(cx, cy) {
+function isTileBlockedByMonster(cx, cy, opts = {}) {
+  const ignoreHero = !!(opts && typeof opts === 'object' && opts.ignoreHero);
   const key = monsterTileKey(cx, cy);
+  if (!ignoreHero && HERO_BLOCK_STATE?.tiles?.has?.(key)) return true;
   const set = MONSTER_BLOCKED_TILES.get(key);
   if (!set || !set.size) return false;
   let alive = false;
@@ -785,7 +932,7 @@ function applyServerPosition(id, sprite, x, y, opts = {}) {
     }
   }
 
-  updateMonsterBlocking(state, x / TILE, y / TILE);
+  updateMonsterBlocking(state, x, y);
   state.lastServerAt = now;
   SERVER_MONSTER_STATE.set(String(id), state);
 }
@@ -1084,7 +1231,16 @@ function triggerMonsterAttackAnimation(msg = {}) {
     face = pickFaceFromDelta(dx, dy, face);
   }
 
-  setMonsterAction(state, sprite, 'attack', { face, until: now + 520 });
+  const msgInterval = Number(msg.attackIntervalMs ?? msg.attackMs ?? msg.attack_ms);
+  const monsterInterval = Number(msg.monster?.attackIntervalMs ?? msg.monster?.attackInterval ?? msg.monster?.attack_ms);
+  let attackDuration = Number.isFinite(msgInterval) && msgInterval > 0
+    ? msgInterval
+    : Number.isFinite(monsterInterval) && monsterInterval > 0
+      ? monsterInterval
+      : 520;
+  attackDuration = Math.max(260, Math.min(attackDuration, 6000));
+
+  setMonsterAction(state, sprite, 'attack', { face, until: now + attackDuration });
   state.animSpeedMultiplier = SERVER_MONSTER_IDLE_ANIM;
   state.dead = false;
   state.face = face;
@@ -1124,6 +1280,9 @@ onMessage('mob_pos', handleLegacyMobPos);
 onMessage('monster_dead', handleServerMonsterDead);
 window.GameScene.serverMonsters = SERVER_MONSTER_STATE;
 window.GameScene.isTileBlockedByMonster = isTileBlockedByMonster;
+window.GameScene.heroBlockedTiles = HERO_BLOCK_STATE.tiles;
+window.GameScene.updateHeroBlocking = updateHeroBlocking;
+window.GameScene.clearHeroBlocking = clearHeroBlocking;
 window.GameScene.monsterBlockedTiles = MONSTER_BLOCKED_TILES;
 
 // =============== Canvas/HUD flexível (querystring + auto) ===============
@@ -1441,9 +1600,6 @@ function drawLoot(l) {
   ctx.restore();
 }
 
-/* ========================= Player Visual ========================== */
-const playerVis = { w: 32, h: 32, img: null, heroKey: null };
-
 /* ============================== Render ============================ */
 function clear() { ctx.clearRect(0, 0, canvas.width, canvas.height); }
 
@@ -1476,8 +1632,10 @@ function drawGround(cameraObj) {
 function drawPlayer(controller) {
   const p = controller.getPosition();
   if (imgReady(playerVis.img)) {
-    const ox = Math.round(p.x - playerVis.w * 0.5);
-    const oy = Math.round(p.y - playerVis.h * 0.9);
+    const anchorX = Number.isFinite(playerVis.anchorX) ? playerVis.anchorX : 0.5;
+    const anchorY = Number.isFinite(playerVis.anchorY) ? playerVis.anchorY : 0.9;
+    const ox = Math.round(p.x - playerVis.w * anchorX);
+    const oy = Math.round(p.y - playerVis.h * anchorY);
     ctx.drawImage(playerVis.img, ox, oy, playerVis.w, playerVis.h);
   } else {
     ctx.save();
@@ -1838,53 +1996,13 @@ function updateRespawns(now) {
   }
 }
 
-// === UI mínima: números de dano flutuantes ===
-(function(){
-  const ACTIVE = []; // {x,y,amt,t,life}
-  const LIFE_MS = 900;
-
-  function spawn({ x, y, amount, kind }) {
-    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
-    ACTIVE.push({ x, y, amt: Number(amount)||0, t: performance.now(), life: LIFE_MS, kind: String(kind||'') });
-  }
-
-  function render(ctx, camera, dt) {
-    if (!ACTIVE.length) return;
-    const now = performance.now();
-    for (let i = ACTIVE.length - 1; i >= 0; i--) {
-      const p = ACTIVE[i];
-      const age = now - p.t;
-      if (age >= p.life) { ACTIVE.splice(i,1); continue; }
-      const alpha = 1 - (age / p.life);
-      const rise = Math.min(22, age * 0.04);
-      const sx = (p.x - camera.x) * (camera.getZoom?.()||1);
-      const sy = (p.y - camera.y - rise) * (camera.getZoom?.()||1);
-
-      ctx.save();
-      ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
-      ctx.font = 'bold 14px monospace';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      // contorno simples
-      ctx.fillStyle = 'black';
-      ctx.fillText(String(p.amt), Math.round(sx)+1, Math.round(sy)+1);
-      // dentro (vermelho padrão para dano recebido)
-      ctx.fillStyle = (p.kind === 'from_mob') ? '#ff6767' : '#ffd54a';
-      ctx.fillText(String(p.amt), Math.round(sx), Math.round(sy));
-      ctx.restore();
-    }
-  }
-
-  window.HeroDamageUI = { spawn, render };
-})();
-
-
 /* ================================ Boot ================================ */
 (async function main() {
   await getCsrf().catch(() => {});
   await bootAuth();
   console.log('[ws-auth] autenticado, o servidor agora conhece seu player_id');
   await loadSpriteMeta();
+  clearHeroBlocking();
 
   const maps = await apiGet("/api/admin/content/maps");
   if (!maps.some((m) => m.key === MAP_KEY)) throw new Error(`map ${MAP_KEY} não encontrado`);
@@ -1979,7 +2097,7 @@ function updateRespawns(now) {
 
   resize();
 
-  const monsterBlockChecker = (cx, cy) => isTileBlockedByMonster(cx, cy);
+  const monsterBlockChecker = (cx, cy) => isTileBlockedByMonster(cx, cy, { ignoreHero: true });
 
   const controller = new PlayerController({
     speed: 140,
@@ -1993,6 +2111,14 @@ function updateRespawns(now) {
       publishPos(x, y);
     },
   });
+
+  if (controller && typeof controller.setPosition === 'function') {
+    const originalSetPosition = controller.setPosition.bind(controller);
+    controller.setPosition = function patchedSetPosition(x, y) {
+      originalSetPosition(x, y);
+      if (Number.isFinite(x) && Number.isFinite(y)) updateHeroBlocking(x, y);
+    };
+  }
 
   if (typeof controller.setDynamicBlockChecker === 'function') {
     controller.setDynamicBlockChecker(monsterBlockChecker);
@@ -2109,7 +2235,14 @@ function updateRespawns(now) {
     // Teclado: 1 passo de 32x32 por tecla (N/S/L/O)
     const step = Input.getStepIntent && Input.getStepIntent();
     if (step) window.GameScene?.controller?.requestStep?.(step);
-    window.GameScene?.controller?.update?.(dt, null);
+    const ctrlInstance = window.GameScene?.controller;
+    ctrlInstance?.update?.(dt, null);
+    if (ctrlInstance?.getPosition) {
+      const pos = ctrlInstance.getPosition();
+      if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) {
+        updateHeroBlocking(pos.x, pos.y);
+      }
+    }
 
     // Camera
     camera.update(dt);

--- a/client/js/ui/hero-floating-damage.js
+++ b/client/js/ui/hero-floating-damage.js
@@ -2,51 +2,99 @@
 import { onMessage } from '../ws/singleton.js';
 
 (function () {
-  const POPS = []; // {x,y,text,life,duration,vy}
+  const POPS = []; // {x,y,text,kind,created,duration,vy}
   const LIFE_MS = 800;
+  const MAX_POPUPS = 40;
+  const DEFAULT_OFFSET_Y = 18;
 
   function now() { return performance.now(); }
 
-  // posição atual do herói (aproximação)
-  function getHeroWorldPos() {
+  function activeHeroId() {
     try {
-      const ctrl = window.GameScene?.controller;
-      if (ctrl && typeof ctrl.getPosition === 'function') return ctrl.getPosition();
+      if (window.Team?.getActiveHeroId) {
+        const id = window.Team.getActiveHeroId();
+        if (id != null) return String(id);
+      }
     } catch {}
-    return { x: 0, y: 0 };
+    if (window.ActiveHeroId != null) return String(window.ActiveHeroId);
+    return null;
   }
 
-  function addPopup(text, { x, y }) {
-    POPS.push({ x, y, text: String(text), created: now(), duration: LIFE_MS, vy: -28 });
-    if (POPS.length > 40) POPS.shift();
+  // posição atual do herói ativo (aproximação)
+  function getHeroWorldPos(heroId) {
+    if (heroId != null) {
+      const active = activeHeroId();
+      if (active && String(heroId) !== active) return null;
+    }
+    try {
+      const ctrl = window.GameScene?.controller;
+      if (ctrl && typeof ctrl.getPosition === 'function') {
+        const pos = ctrl.getPosition();
+        if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) return pos;
+      }
+    } catch {}
+    return null;
+  }
+
+  function pushPopup({ x, y, text, kind }) {
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    POPS.push({ x, y: y - DEFAULT_OFFSET_Y, text: String(text ?? ''), kind: kind || '', created: now(), duration: LIFE_MS, vy: -28 });
+    if (POPS.length > MAX_POPUPS) POPS.shift();
+  }
+
+  function normalizeText(amount, kind) {
+    if (amount == null) return '';
+    if (typeof amount === 'string') return amount;
+    const num = Number(amount);
+    if (!Number.isFinite(num)) return String(amount);
+    const base = Math.round(Math.abs(num));
+    if (kind === 'from_mob' || kind === 'damage' || kind === 'hit') return `-${base}`;
+    if (kind === 'heal' || kind === 'from_heal' || kind === 'heal_self') return `+${base}`;
+    return String(num);
+  }
+
+  function spawn({ x, y, amount, kind }) {
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    const text = normalizeText(amount, kind);
+    pushPopup({ x, y, text, kind });
+  }
+
+  function spawnAtHero(amount, byKind, heroId) {
+    const pos = getHeroWorldPos(heroId);
+    if (pos) {
+      spawn({ x: pos.x, y: pos.y, amount, kind: byKind || 'from_mob' });
+      return true;
+    }
+    return false;
   }
 
   // WS: quando **o herói** leva dano
   onMessage('hero_dmg', (m) => {
-    const activeId = (window.Team?.getActiveHeroId && window.Team.getActiveHeroId()) || window.ActiveHeroId || null;
-    if (!activeId) return;
-    if (String(m.heroId) !== String(activeId)) return;
+    const active = activeHeroId();
+    if (!active || String(m.heroId) !== active) return;
+    if (spawnAtHero(m.amount, 'from_mob', m.heroId)) return;
 
-    // origem no herói
-    const p = getHeroWorldPos();
-    addPopup(`-${m.amount}`, p);
-
-    // opcional: escrever no chat-log também
-    if (window.Chat?.pushLog) {
-      window.Chat.pushLog(`[Dano] ${m.byMob ?? m.instanceId} → você: ${m.amount}`);
+    const ctrl = window.GameScene?.controller;
+    const pos = ctrl?.getPosition?.();
+    if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) {
+      spawn({ x: pos.x, y: pos.y, amount: m.amount, kind: 'from_mob' });
     }
   });
 
   // (opcional) mostra “+N” ao curar (se um dia emitir hero_heal)
   onMessage('hero_heal', (m) => {
-    const activeId = (window.Team?.getActiveHeroId && window.Team.getActiveHeroId()) || window.ActiveHeroId || null;
-    if (!activeId) return;
-    if (String(m.heroId) !== String(activeId)) return;
-    const p = getHeroWorldPos();
-    addPopup(`+${m.amount}`, p);
+    const active = activeHeroId();
+    if (!active || String(m.heroId) !== active) return;
+    if (spawnAtHero(m.amount, 'heal', m.heroId)) return;
+
+    const ctrl = window.GameScene?.controller;
+    const pos = ctrl?.getPosition?.();
+    if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) {
+      spawn({ x: pos.x, y: pos.y, amount: m.amount, kind: 'heal' });
+    }
   });
 
-  function render(ctx, camera, dt) {
+  function render(ctx, camera) {
     if (!ctx || !camera) return;
     const t = now();
 
@@ -77,13 +125,14 @@ import { onMessage } from '../ws/singleton.js';
       ctx.fillText(p.text, sx - 1, sy - 1);
 
       // texto
-      ctx.fillStyle = '#ef4444'; // vermelho (dano); se curar, mude para verde
-      if (p.text.startsWith('+')) ctx.fillStyle = '#10b981';
+      let color = '#ef4444';
+      if (p.kind === 'heal' || p.text.startsWith('+')) color = '#10b981';
+      ctx.fillStyle = color;
       ctx.fillText(p.text, sx, sy);
       ctx.restore();
     }
   }
 
   // API pública para o loop principal
-  window.HeroDamageUI = { render };
+  window.HeroDamageUI = { spawn, render, spawnAtHero };
 })();

--- a/data/sprites/monsters/bear.yml
+++ b/data/sprites/monsters/bear.yml
@@ -27,7 +27,7 @@ anims:
     loop: true
 
   walk:
-    fps: 8
+    fps: 3
     frames: 5 # padrão
     framesByDir:
       # override por direção

--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -879,7 +879,16 @@ async function stepMob(now, dt, mob, heroes, losGrid, occupancy, heroTiles) {
         await applyMobHit({
           attackerInstanceId: String(mob.instanceId),
           targetHeroId: String(mob.targetHeroId),
-          attackInfo: { min: 1, max: 3 }
+          attackInfo: { min: 1, max: 3 },
+          attackerPos: {
+            x: Number.isFinite(mob.x) ? mob.x : undefined,
+            y: Number.isFinite(mob.y) ? mob.y : undefined,
+            mapKey: mob.mapKey,
+            face: mob.face,
+            unit: 'px',
+            assumeTiles: false,
+            assumePx: true,
+          },
         });
       } catch (e) {
         console.warn('[ai-mobs] applyMobHit error:', e?.message);

--- a/server/combat/monster_atk_simple.js
+++ b/server/combat/monster_atk_simple.js
@@ -2,6 +2,7 @@
 const { all, run } = require('../models/db'); // helpers do projeto
 const { applyMobHit } = require('./service');
 const { getGrid } = require('../maps/grid');
+const { getMonster } = require('../services/catalogCache');
 
 // ======= Tuning via .env =======
 const TILE = 32;
@@ -17,6 +18,12 @@ const MONSTER_PERSIST_POS_MS = +(process.env.MONSTER_PERSIST_POS_MS || 1000); //
 const ATK_COOLDOWN_MS = +(process.env.MONSTER_ATK_COOLDOWN_MS || 900);
 const DMG_MIN  = +(process.env.MONSTER_BASE_DMG_MIN || 6);
 const DMG_MAX  = +(process.env.MONSTER_BASE_DMG_MAX || 12);
+const DEFAULT_ATTACK_PROFILE = Object.freeze({
+  min: DMG_MIN,
+  max: DMG_MAX,
+  intervalMs: ATK_COOLDOWN_MS,
+  chancePercent: 100,
+});
 
 // Gate do spawn (agora DESLIGADO por padrão)
 const CHASE_INSIDE_SPAWN_ONLY = (process.env.MONSTER_CHASE_INSIDE_SPAWN_ONLY ?? '0') === '1';
@@ -56,11 +63,150 @@ const _aggroUntil     = new Map(); // monsterId -> ms timestamp
 const _patrolTargets  = new Map(); // monsterId -> { tx, ty, expiresAt }
 const _lastPatrolMove = new Map(); // monsterId -> ms
 const _heroMemory     = new Map(); // heroId -> { tx, ty, lastTx, lastTy, heading, updatedAt, mapKey }
+const _attackProfileCache = new Map(); // monsterKey -> { profile, signature }
+const _attackWarnedKeys = new Set();
 
 // ======= Utils =======
 const tileOf = (v) => Math.floor(Number(v || 0) / TILE);
 const centerOfTile = (t) => (t * TILE) + TILE / 2;
 const tileKey = (tx, ty) => `${tx},${ty}`;
+
+function toFiniteNumber(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(value, min, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return min;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+function parseAttacksPayload(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  if (typeof raw === 'object') {
+    if (Array.isArray(raw.attacks)) return raw.attacks;
+    if (Array.isArray(raw.list)) return raw.list;
+    if (Array.isArray(raw.data)) return raw.data;
+    if (Array.isArray(raw.entries)) return raw.entries;
+    if (Array.isArray(raw.values)) return raw.values;
+    if (Array.isArray(raw.melee)) return raw.melee;
+    try {
+      const values = Object.values(raw).filter(v => typeof v === 'object');
+      return Array.isArray(values) ? values : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function buildAttackProfile(entry, fallbackIntervalMs) {
+  if (!entry || typeof entry !== 'object') {
+    return { ...DEFAULT_ATTACK_PROFILE };
+  }
+
+  const min = toFiniteNumber(
+    entry.min ?? entry.minDamage ?? entry.min_dmg ?? entry.damageMin,
+    DEFAULT_ATTACK_PROFILE.min,
+  );
+  let max = toFiniteNumber(
+    entry.max ?? entry.maxDamage ?? entry.max_dmg ?? entry.damageMax,
+    Math.max(min, DEFAULT_ATTACK_PROFILE.max),
+  );
+  if (!Number.isFinite(max) || max < min) max = Math.max(min, DEFAULT_ATTACK_PROFILE.max);
+
+  let intervalMs = toFiniteNumber(
+    entry.intervalMs ?? entry.interval_ms ?? entry.cooldownMs ?? entry.cooldown,
+    Number.isFinite(fallbackIntervalMs) && fallbackIntervalMs > 0 ? fallbackIntervalMs : DEFAULT_ATTACK_PROFILE.intervalMs,
+  );
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) intervalMs = DEFAULT_ATTACK_PROFILE.intervalMs;
+
+  let chancePercent = clamp(
+    entry.chancePercent ?? entry.chance,
+    0,
+    100,
+  );
+  if (!Number.isFinite(chancePercent)) chancePercent = DEFAULT_ATTACK_PROFILE.chancePercent;
+
+  return {
+    min,
+    max,
+    intervalMs,
+    chancePercent,
+  };
+}
+
+function computeAttackSignature(monster) {
+  if (!monster) return null;
+  const raw = monster.attacks_json;
+  if (typeof raw === 'string') return raw.trim();
+  if (Array.isArray(raw)) {
+    try { return JSON.stringify(raw); } catch { return null; }
+  }
+  if (raw && typeof raw === 'object') {
+    try { return JSON.stringify(raw); } catch { return null; }
+  }
+  return null;
+}
+
+async function resolveMonsterAttackProfile(monster) {
+  if (!monster) return DEFAULT_ATTACK_PROFILE;
+  const key = monster.monster_key != null ? String(monster.monster_key) : null;
+  if (!key) return DEFAULT_ATTACK_PROFILE;
+
+  const signature = computeAttackSignature(monster);
+  const cached = _attackProfileCache.get(key);
+  if (cached && cached.profile && cached.signature === signature) {
+    return cached.profile;
+  }
+
+  let attacks = parseAttacksPayload(monster.attacks_json);
+
+  if (!attacks.length && typeof getMonster === 'function') {
+    try {
+      const catalogMonster = await getMonster(key);
+      if (catalogMonster) {
+        attacks = parseAttacksPayload(catalogMonster.attacks || catalogMonster.attacksJSON);
+      }
+    } catch (err) {
+      if (!_attackWarnedKeys.has(key)) {
+        console.warn(`[monster_atk_simple] failed to load attacks for ${key}:`, err?.message);
+        _attackWarnedKeys.add(key);
+      }
+    }
+  }
+
+  let chosen = null;
+  for (const entry of attacks) {
+    if (!entry || typeof entry !== 'object') continue;
+    const type = String(entry.type || '').toLowerCase();
+    if (type === 'melee') { chosen = entry; break; }
+    if (!chosen) chosen = entry;
+  }
+
+  if (!chosen && !_attackWarnedKeys.has(key)) {
+    console.warn(`[monster_atk_simple] no melee attack configured for ${key}, using defaults`);
+    _attackWarnedKeys.add(key);
+  }
+
+  const profile = Object.freeze(buildAttackProfile(chosen, monster.attack_ms));
+  _attackProfileCache.set(key, { profile, signature });
+  return profile;
+}
 
 function toCenterPxCoord(raw) {
   const n = Number(raw);
@@ -825,7 +971,9 @@ async function fetchAliveMonsters() {
            COALESCE(s.w,32)  AS sw,
            COALESCE(s.h,32)  AS sh,
            s."monsterKey"    AS monster_key,
-           COALESCE(mm.name, s."monsterKey") AS monster_name
+           COALESCE(mm.name, s."monsterKey") AS monster_name,
+           mm."attacksJSON" AS attacks_json,
+           mm.attack_ms     AS attack_ms
       FROM monster_instances mi
       LEFT JOIN spawns s ON s.id = mi.spawn_id
       LEFT JOIN monsters_master mm ON mm.key = s."monsterKey"
@@ -975,6 +1123,7 @@ async function tick() {
       }
       const heroTilesForMap = heroTilesByMap.get(mapKeyStr) || new Set();
       const mapCollision = await ensureCollisionFor(m.map_key);
+      const targetInfo = selectHeroTarget({ monster: m, heroes: hs, now });
 
       if (!_wasQuantized.has(m.id)) {
         const mx0 = tileOf(m.x), my0 = tileOf(m.y);
@@ -1122,58 +1271,101 @@ async function tick() {
         if (isGhost || !targetInfo.hero) continue;
 
         const targetHero = targetInfo.hero;
+        const attackProfile = await resolveMonsterAttackProfile(m);
+        const cooldownMs = Math.max(50, Number(attackProfile?.intervalMs || ATK_COOLDOWN_MS));
+        const chancePercent = clamp(attackProfile?.chancePercent ?? 100, 0, 100);
         const lastAtk = _lastAtkAt.get(m.id) || 0;
-        if (now - lastAtk < ATK_COOLDOWN_MS) continue;
+        if (now - lastAtk < cooldownMs) continue;
 
+        if (chancePercent < 100) {
+          const roll = Math.random() * 100;
+          if (roll >= chancePercent) {
+            _lastAtkAt.set(m.id, now);
+            continue;
+          }
+        }
+
+        let attackRes = null;
         try {
-          const attackRes = await applyMobHit({
+          attackRes = await applyMobHit({
             attackerInstanceId: m.id,
             targetHeroId: targetHero.hero_id,
-            attackInfo: { min: DMG_MIN, max: DMG_MAX },
+            attackInfo: {
+              min: attackProfile?.min ?? DMG_MIN,
+              max: attackProfile?.max ?? DMG_MAX,
+            },
+            attackerPos: {
+              x: Number.isFinite(m.x) ? m.x : undefined,
+              y: Number.isFinite(m.y) ? m.y : undefined,
+              mapKey: targetHero.map_key ?? m.map_key,
+              face: m.face,
+              unit: 'px',
+              assumeTiles: false,
+              assumePx: true,
+            },
           });
-
-          if (attackRes?.ok) {
-            await markLastHit(m.id, targetHero.hero_id);
-            _lastAtkAt.set(m.id, now);
-            _aggroUntil.set(m.id, now + AGGRO_LOSS_MS);
-
-            if (attackRes.dead) {
-              const arr = heroesByMap.get(targetHero.map_key);
-              if (arr) {
-                const idx = arr.findIndex(hh => String(hh.hero_id) === String(targetHero.hero_id));
-                if (idx >= 0) arr.splice(idx, 1);
-              }
-            } else if (attackRes.hpAfter != null) {
-              targetHero.hp = attackRes.hpAfter;
-            }
-
-            updateLivePos(m);
-            emitMonsterMove(m);
-
-            if (global._sendToMap) {
-              global._sendToMap(targetHero.map_key, {
-                type: 'hero_hit',
-                heroId: targetHero.hero_id,
-                dmg: attackRes.damage,
-                hp: attackRes.hpAfter,
-                hpMax: attackRes.maxHp ?? targetHero.max_hp,
-                died: attackRes.dead,
-                instanceId: m.id,
-                monster: {
-                  id: m.id,
-                  key: m.monster_key || 'unknown',
-                  name: m.monster_name || m.monster_key || 'Monster',
-                  x: m.x,
-                  y: m.y,
-                  mapKey: targetHero.map_key,
-                  spawnId: m.spawn_id,
-                  face: m.face,
-                },
-              });
-            }
-          }
         } catch (err) {
           console.warn('[monster_atk_simple] applyMobHit error:', err?.message);
+        }
+
+        if (attackRes?.ok) {
+          if (attackRes.attackerPos) {
+            const ax = Number(attackRes.attackerPos.x);
+            const ay = Number(attackRes.attackerPos.y);
+            if (Number.isFinite(ax)) m.x = ax;
+            if (Number.isFinite(ay)) m.y = ay;
+            const faceFromHit = typeof attackRes.attackerPos.face === 'string' ? attackRes.attackerPos.face : null;
+            if (faceFromHit) m.face = faceFromHit;
+          }
+          _lastAtkAt.set(m.id, now);
+          await markLastHit(m.id, targetHero.hero_id);
+          _aggroUntil.set(m.id, now + AGGRO_LOSS_MS);
+
+          if (attackRes.dead) {
+            const arr = heroesByMap.get(targetHero.map_key);
+            if (arr) {
+              const idx = arr.findIndex(hh => String(hh.hero_id) === String(targetHero.hero_id));
+              if (idx >= 0) arr.splice(idx, 1);
+            }
+          } else if (attackRes.hpAfter != null) {
+            targetHero.hp = attackRes.hpAfter;
+            if (attackRes.heroPos) {
+              const hx2 = Number(attackRes.heroPos.x);
+              const hy2 = Number(attackRes.heroPos.y);
+              if (Number.isFinite(hx2)) targetHero.x = hx2;
+              if (Number.isFinite(hy2)) targetHero.y = hy2;
+            }
+          }
+
+          updateLivePos(m);
+
+          if (global._sendToMap) {
+            const attackIntervalMs = cooldownMs;
+            const hitMapKey = attackRes.attackerPos?.mapKey ?? targetHero.map_key ?? m.map_key;
+            if (hitMapKey != null) targetHero.map_key = hitMapKey;
+            global._sendToMap(hitMapKey, {
+              type: 'hero_hit',
+              heroId: targetHero.hero_id,
+              dmg: attackRes.damage,
+              hp: attackRes.hpAfter,
+              hpMax: attackRes.maxHp ?? targetHero.max_hp,
+              died: attackRes.dead,
+              instanceId: m.id,
+              face: m.face,
+              attackIntervalMs,
+              monster: {
+                id: m.id,
+                key: m.monster_key || 'unknown',
+                name: m.monster_name || m.monster_key || 'Monster',
+                x: m.x,
+                y: m.y,
+                mapKey: hitMapKey,
+                spawnId: m.spawn_id,
+                face: m.face,
+                attackIntervalMs,
+              },
+            });
+          }
         }
 
         continue;

--- a/server/combat/routes.js
+++ b/server/combat/routes.js
@@ -10,7 +10,7 @@ const K = require('../balance/config');
 
 const { get } = require('../models/db');
 
-const { getHeroPos, getMonsterPos, isHeroPosFresh } = require('./pos');
+const { getHeroPos, getMonsterPos } = require('./pos');
 
 const { inReachPx, resolveRangeTiles, distanceToTargetPx, TILE } = require('./geom');
 const { hasLineOfSight } = require('./los');
@@ -120,23 +120,6 @@ function buildNoLoSPayload(ctx) {
   };
 }
 
-function buildStaleHeroPosPayload(ctx) {
-  const message = 'Posição do herói desatualizada. Aguarde sincronizar movendo o personagem.';
-  return {
-    ok: false,
-    error: 'hero-pos-stale',
-    inRange: false,
-    hasLineOfSight: ctx?.hasLineOfSight ?? null,
-    range: ctx?.range || null,
-    distance: ctx?.distance || null,
-    hero: ctx?.hero || null,
-    monster: ctx?.monster || null,
-    computedAt: ctx?.computedAt || Date.now(),
-    message,
-    warnings: [{ code: 'hero-pos-stale', message }],
-  };
-}
-
 /* =========================================================================
    Logging básico
    ========================================================================== */
@@ -216,10 +199,6 @@ router.post('/attack/start', express.json(), async (req, res) => {
     }
 
     const telemetry = buildRangeTelemetry(heroPos, mobPos, weaponType);
-    if (!isHeroPosFresh(heroPos)) {
-      return res.json(buildStaleHeroPosPayload(telemetry));
-    }
-
     const { grid, cols } = await getGrid(heroPos.map_key);
     const losGrid = { data: grid, cols };
 
@@ -325,10 +304,6 @@ router.post('/hit', express.json(), async (req, res) => {
     }
 
     const telemetry = buildRangeTelemetry(heroPos, mobPos, weaponType);
-    if (!isHeroPosFresh(heroPos)) {
-      return res.json(buildStaleHeroPosPayload(telemetry));
-    }
-
     const { grid, cols } = await getGrid(heroPos.map_key);
     const losGrid = { data: grid, cols };
 

--- a/server/combat/service.js
+++ b/server/combat/service.js
@@ -4,7 +4,7 @@ const { get, run } = require('../models/db');
 const K = require('../balance/config');
 const { applyTries, getClassRate } = require('../skills/engine');
 const { broadcast } = require('../ws/bus');
-const { resolveHitboxDimension } = require('./geom');
+const { resolveHitboxDimension, TILE } = require('./geom');
 // Se você usa este serviço central de XP:
 const { giveXp } = require('../services/heroProgress');
 
@@ -85,9 +85,6 @@ LEFT JOIN items_master     i ON i.key = eq.item_key
 
 /** Instância do monstro + dados do monstro (xp/loot/armor) */
 async function getInstanceWithMonster(instanceId) {
-  // se precisar, troque 32 pelo tamanho do seu tile
-  const TILE = 32;
-
   return await get(
     `SELECT mi.id, mi.hp, mi.max_hp, mi.state, mi.spawn_id, mi.map_key,
             mi.x, mi.y,
@@ -333,9 +330,62 @@ async function applyHit({ attackerHeroId, targetInstanceId, weaponType }) {
 // server/combat/service.js
 // server/combat/service.js - TRECHO applyMobHit CORRIGIDO
 
-async function applyMobHit({ attackerInstanceId, targetHeroId, attackInfo }) {
+function normalizeCombatPosition(rawPos, fallback = {}) {
+  const pos = rawPos || {};
+  const fb = fallback || {};
+
+  const mapKey =
+    pos.mapKey ?? pos.map_key ?? pos.map ??
+    fb.mapKey ?? fb.map_key ?? fb.map ??
+    null;
+
+  const face = pos.face ?? fb.face ?? null;
+
+  const unit = typeof pos.unit === 'string' ? pos.unit.toLowerCase() : null;
+  const explicitTiles = pos.inTiles === true || pos.tiles === true || unit === 'tile' || unit === 'tiles';
+  const explicitPx = pos.inPixels === true || pos.pixels === true || unit === 'px' || unit === 'pixel' || unit === 'pixels';
+  const assumeTiles = pos.assumeTiles;
+  const assumePx = pos.assumePx;
+
+  let x = Number(pos.x);
+  let y = Number(pos.y);
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    x = Number(fb.x);
+    y = Number(fb.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return { x: null, y: null, mapKey, face };
+    }
+
+    const fbUnit = typeof fb.unit === 'string' ? fb.unit.toLowerCase() : null;
+    const fbTiles = fb.inTiles === true || fb.tiles === true || fbUnit === 'tile' || fbUnit === 'tiles';
+    const fbPx = fb.inPixels === true || fb.pixels === true || fbUnit === 'px' || fbUnit === 'pixel' || fbUnit === 'pixels';
+
+    if (fbTiles || (!fbPx && Math.abs(x) < 1000 && Math.abs(y) < 1000)) {
+      x = (x * TILE) + (TILE / 2);
+      y = (y * TILE) + (TILE / 2);
+    }
+
+    return { x, y, mapKey, face };
+  }
+
+  if (explicitTiles) {
+    x = (x * TILE) + (TILE / 2);
+    y = (y * TILE) + (TILE / 2);
+  } else if (!explicitPx) {
+    const shouldAssumeTiles = assumeTiles === true
+      || (assumeTiles !== false && !assumePx && Math.abs(x) < 1000 && Math.abs(y) < 1000);
+    if (shouldAssumeTiles) {
+      x = (x * TILE) + (TILE / 2);
+      y = (y * TILE) + (TILE / 2);
+    }
+  }
+
+  return { x, y, mapKey, face };
+}
+
+async function applyMobHit({ attackerInstanceId, targetHeroId, attackInfo, attackerPos = null, heroPos = null }) {
   const DEBUG_COMBAT = String(process.env.COMBAT_DEBUG || '').trim() === '1';
-  const TILE = 32;
 
   const hero = await getHeroStats(targetHeroId);
   if (!hero) return { ok: false, message: 'target hero not found' };
@@ -343,38 +393,93 @@ async function applyMobHit({ attackerInstanceId, targetHeroId, attackInfo }) {
   const inst = await getInstanceWithMonster(attackerInstanceId);
   if (!inst || inst.state !== 'ALIVE') return { ok: false, message: 'attacker not alive' };
 
+  const fallbackAttackerPos = {
+    x: inst.x,
+    y: inst.y,
+    mapKey: inst.map_key,
+    unit: (Math.abs(Number(inst.x) || 0) < 1000 && Math.abs(Number(inst.y) || 0) < 1000) ? 'tile' : 'px',
+  };
+
+  const attacker = normalizeCombatPosition(attackerPos, fallbackAttackerPos);
+  const effectiveMapKey = attacker.mapKey ?? inst.map_key;
+  let mx = Number(attacker.x);
+  let my = Number(attacker.y);
+  const attackerFace = attacker.face ?? null;
+
+  if (!Number.isFinite(mx) || !Number.isFinite(my)) {
+    mx = Number(inst.x || 0);
+    my = Number(inst.y || 0);
+    if (mx < 1000 && my < 1000) {
+      mx = (mx * TILE) + (TILE / 2);
+      my = (my * TILE) + (TILE / 2);
+    }
+  }
+
   // --- POSIÇÃO DO HERÓI (SEMPRE EM PIXELS) ---
   let hpos = null;
   let heroPosFresh = false;
-  try {
-    const mod = posMod();
-    if (mod && typeof mod.getHeroPos === 'function') {
-      hpos = await mod.getHeroPos(hero.hero_id, inst.map_key);
-      if (hpos && typeof mod.isHeroPosFresh === 'function') {
-        heroPosFresh = mod.isHeroPosFresh(hpos);
-      } else if (hpos) {
-        heroPosFresh = hpos.fresh === true || (hpos.source === 'live' && hpos.stale === false);
-      }
-    }
-  } catch {}
 
-  if (!hpos || String(hpos.map_key) !== String(inst.map_key)) {
+  if (heroPos) {
+    const heroOverride = normalizeCombatPosition(heroPos, { mapKey: effectiveMapKey });
+    if (Number.isFinite(heroOverride.x) && Number.isFinite(heroOverride.y)) {
+      hpos = {
+        x: heroOverride.x,
+        y: heroOverride.y,
+        map_key: heroOverride.mapKey ?? effectiveMapKey,
+        source: heroPos.source ?? 'override',
+        stale: heroPos.stale ?? false,
+        fresh: heroPos.fresh ?? true,
+      };
+      heroPosFresh = hpos.fresh === true;
+    }
+  }
+
+  if (!hpos) {
+    try {
+      const mod = posMod();
+      if (mod && typeof mod.getHeroPos === 'function') {
+        hpos = await mod.getHeroPos(hero.hero_id, effectiveMapKey);
+        if (hpos && typeof mod.isHeroPosFresh === 'function') {
+          heroPosFresh = mod.isHeroPosFresh(hpos);
+        } else if (hpos) {
+          heroPosFresh = hpos.fresh === true || (hpos.source === 'live' && hpos.stale === false);
+        }
+      }
+    } catch {}
+  }
+
+  if (hpos && hpos.map_key == null && effectiveMapKey != null) {
+    hpos.map_key = effectiveMapKey;
+  }
+
+  if (!hpos || String(hpos.map_key) !== String(effectiveMapKey)) {
     return { ok: false, message: 'target not in same map' };
   }
 
-  let hx = Number(hpos.x || 0);
-  let hy = Number(hpos.y || 0);
+  const heroNormInput = {
+    x: hpos.x,
+    y: hpos.y,
+    mapKey: hpos.map_key,
+  };
+  if (hpos.source === 'live' || hpos.source === 'live_stale') {
+    heroNormInput.assumeTiles = false;
+    heroNormInput.assumePx = true;
+  }
 
-  // Normaliza para pixels se vier em tiles
-  if (hx < 1000 && hy < 1000) {
-    hx = (hx * TILE) + (TILE / 2);
-    hy = (hy * TILE) + (TILE / 2);
+  const heroNorm = normalizeCombatPosition(heroNormInput, { x: hpos.x, y: hpos.y, mapKey: hpos.map_key });
+  let hx = Number(heroNorm.x || 0);
+  let hy = Number(heroNorm.y || 0);
+
+  if (!Number.isFinite(hx) || !Number.isFinite(hy)) {
+    hx = Number(hpos.x || 0);
+    hy = Number(hpos.y || 0);
+    if (hx < 1000 && hy < 1000) {
+      hx = (hx * TILE) + (TILE / 2);
+      hy = (hy * TILE) + (TILE / 2);
+    }
   }
 
   // --- HITBOX DO MONSTRO (considera tamanho da sprite) ---
-  let mx = Number(inst.x || 0);
-  let my = Number(inst.y || 0);
-  
   if (mx < 1000 && my < 1000) {
     mx = (mx * TILE) + (TILE / 2);
     my = (my * TILE) + (TILE / 2);
@@ -404,26 +509,30 @@ async function applyMobHit({ attackerInstanceId, targetHeroId, attackInfo }) {
 
   // Linha de visão
   let hasLOS = true;
-  try {
-    const { getGrid } = require('../maps/grid');
-    const { hasLineOfSight } = require('./los');
-    const { grid, cols } = await getGrid(inst.map_key);
-    hasLOS = hasLineOfSight({ data: grid, cols }, mx, my, hx, hy);
-  } catch {}
+  const mapKeyForLos = effectiveMapKey ?? inst.map_key;
+  if (mapKeyForLos != null) {
+    try {
+      const { getGrid } = require('../maps/grid');
+      const { hasLineOfSight } = require('./los');
+      const { grid, cols } = await getGrid(mapKeyForLos);
+      hasLOS = hasLineOfSight({ data: grid, cols }, mx, my, hx, hy);
+    } catch {}
+  }
 
   // DEBUG
   if (DEBUG_COMBAT) {
     console.log('[MOB-HIT-DEBUG]', {
       inst: inst.id,
       hero: targetHeroId,
-      heroPos: { x: hx, y: hy, source: hpos.source },
-      mobPos: { x: mx, y: my },
+      heroPos: { x: hx, y: hy, source: hpos.source, mapKey: hpos.map_key },
+      mobPos: { x: mx, y: my, mapKey: mapKeyForLos, face: attackerFace },
       mobHitbox: { left: mobLeft, right: mobRight, top: mobTop, bottom: mobBottom },
       closest: { x: closestX, y: closestY },
       distPx,
       atkPx,
       inRange: inRangePx,
-      hasLOS
+      hasLOS,
+      heroPosFresh
     });
   }
 
@@ -511,7 +620,9 @@ async function applyMobHit({ attackerInstanceId, targetHeroId, attackInfo }) {
     maxHp: row.max_hp,
     dead,
     targetHeroId,
-    attackerInstanceId
+    attackerInstanceId,
+    heroPos: { x: hx, y: hy, mapKey: hpos.map_key, fresh: heroPosFresh },
+    attackerPos: { x: mx, y: my, mapKey: mapKeyForLos, face: attackerFace },
   };
 }
 


### PR DESCRIPTION
## Summary
- revert the play scene to the version shipped in PR #62, removing the recent safe-tile and repositioning logic that blocked hero movement
- reset the bear sprite metadata to its PR #62 timing
- restore the combat routes without the newly added stale-position guardrails so combat uses the earlier behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3efb764fc83279d9a7e4696446f15