### PR TITLE
Restore monster solid collisions with heroes

### DIFF
--- a/client/js/play.js
+++ b/client/js/play.js
@@ -521,6 +521,79 @@ function updateHeroBlocking(px, py) {
   if (!changed) return;
 }
 
+function ensureMonsterMeta(state) {
+  if (!state) return { frameW: TILE, frameH: TILE, anchorX: 0.5, anchorY: 0.9, meta: null };
+  const sprite = state.sprite || null;
+  const metaCandidate = sprite?.meta || state.meta || (state.monsterKey ? findMetaFor(state.monsterKey) : null) || null;
+  if (metaCandidate && !state.meta) state.meta = metaCandidate;
+  if (sprite && metaCandidate && !sprite.meta) sprite.meta = metaCandidate;
+
+  const meta = metaCandidate || {};
+  let frameW = Number(meta.frame?.width);
+  let frameH = Number(meta.frame?.height);
+  if (!Number.isFinite(frameW) || frameW <= 0) frameW = Number(sprite?.w) || TILE;
+  if (!Number.isFinite(frameH) || frameH <= 0) frameH = Number(sprite?.h) || TILE;
+  if (!Number.isFinite(frameW) || frameW <= 0) frameW = TILE;
+  if (!Number.isFinite(frameH) || frameH <= 0) frameH = TILE;
+
+  let anchorX = Number(meta.anchor?.x);
+  let anchorY = Number(meta.anchor?.y);
+  if (!Number.isFinite(anchorX)) anchorX = Number(sprite?.anchor?.x);
+  if (!Number.isFinite(anchorY)) anchorY = Number(sprite?.anchor?.y);
+  if (!Number.isFinite(anchorX)) anchorX = 0.5;
+  if (!Number.isFinite(anchorY)) anchorY = 0.9;
+  anchorX = Math.max(0, Math.min(1, anchorX));
+  anchorY = Math.max(0, Math.min(1, anchorY));
+
+  return { frameW, frameH, anchorX, anchorY, meta: metaCandidate };
+}
+
+function monsterFootboxTiles(state, worldX, worldY) {
+  if (!state) return [];
+  const sprite = state.sprite || null;
+  const { frameW, frameH, anchorX, anchorY } = ensureMonsterMeta(state);
+
+  const px = Number.isFinite(worldX)
+    ? worldX
+    : (Number.isFinite(state.x)
+        ? state.x
+        : (Number.isFinite(sprite?.x) ? sprite.x : NaN));
+  const py = Number.isFinite(worldY)
+    ? worldY
+    : (Number.isFinite(state.y)
+        ? state.y
+        : (Number.isFinite(sprite?.y) ? sprite.y : NaN));
+  if (!Number.isFinite(px) || !Number.isFinite(py)) return [];
+
+  const spriteLeft = px - frameW * anchorX;
+  const spriteTop = py - frameH * anchorY;
+  const spriteBottom = spriteTop + frameH;
+
+  const footHeight = Math.max(TILE / 2, Math.min(TILE, frameH));
+  const tolerance = 2;
+  const rectHeight = footHeight + tolerance * 2;
+  const rectTop = spriteBottom - footHeight - tolerance;
+  const rectWidth = frameW + tolerance * 2;
+  const rectLeft = spriteLeft - tolerance;
+
+  const minCx = Math.floor(rectLeft / TILE);
+  const maxCx = Math.floor((rectLeft + rectWidth - 1) / TILE);
+  const minCy = Math.floor(rectTop / TILE);
+  const maxCy = Math.floor((rectTop + rectHeight - 1) / TILE);
+
+  if (!Number.isFinite(minCx) || !Number.isFinite(maxCx) || !Number.isFinite(minCy) || !Number.isFinite(maxCy)) {
+    return [];
+  }
+
+  const tiles = [];
+  for (let cy = minCy; cy <= maxCy; cy++) {
+    for (let cx = minCx; cx <= maxCx; cx++) {
+      tiles.push(monsterTileKey(cx, cy));
+    }
+  }
+  return tiles;
+}
+
 function removeMonsterFromTile(state) {
   if (!state) return;
   if (!state.blockedTiles) state.blockedTiles = new Set();
@@ -539,67 +612,17 @@ function updateMonsterBlocking(state, worldX, worldY) {
   if (!state.blockedTiles) state.blockedTiles = new Set();
   removeMonsterFromTile(state);
 
-  const sprite = state.sprite || null;
-  const metaCandidate = sprite?.meta || state.meta || (state.monsterKey ? findMetaFor(state.monsterKey) : null) || null;
-  if (metaCandidate && !state.meta) state.meta = metaCandidate;
-  if (sprite && metaCandidate && !sprite.meta) sprite.meta = metaCandidate;
+  const tiles = monsterFootboxTiles(state, worldX, worldY);
+  if (!tiles.length) return;
 
-  const meta = metaCandidate || {};
-  let frameW = Number(meta.frame?.width);
-  let frameH = Number(meta.frame?.height);
-  if (!Number.isFinite(frameW) || frameW <= 0) frameW = Number(sprite?.w) || TILE;
-  if (!Number.isFinite(frameH) || frameH <= 0) frameH = Number(sprite?.h) || TILE;
-  if (!Number.isFinite(frameW) || frameW <= 0) frameW = TILE;
-  if (!Number.isFinite(frameH) || frameH <= 0) frameH = TILE;
-
-  let anchorX = Number(meta.anchor?.x);
-  let anchorY = Number(meta.anchor?.y);
-  if (!Number.isFinite(anchorX)) anchorX = 0.5;
-  if (!Number.isFinite(anchorY)) anchorY = 0.9;
-  anchorX = Math.max(0, Math.min(1, anchorX));
-  anchorY = Math.max(0, Math.min(1, anchorY));
-
-  const px = Number.isFinite(worldX)
-    ? worldX
-    : (Number.isFinite(state.x)
-        ? state.x
-        : (Number.isFinite(sprite?.x) ? sprite.x : NaN));
-  const py = Number.isFinite(worldY)
-    ? worldY
-    : (Number.isFinite(state.y)
-        ? state.y
-        : (Number.isFinite(sprite?.y) ? sprite.y : NaN));
-  if (!Number.isFinite(px) || !Number.isFinite(py)) return;
-
-  const spriteLeft = px - frameW * anchorX;
-  const spriteTop = py - frameH * anchorY;
-  const spriteBottom = spriteTop + frameH;
-
-  const footHeight = Math.max(TILE / 2, Math.min(TILE, frameH));
-  const tolerance = 2;
-  const rectHeight = footHeight + tolerance * 2;
-  const rectTop = spriteBottom - footHeight - tolerance;
-  const rectWidth = frameW + tolerance * 2;
-  const rectLeft = spriteLeft - tolerance;
-
-  const minCx = Math.floor(rectLeft / TILE);
-  const maxCx = Math.floor((rectLeft + rectWidth - 1) / TILE);
-  const minCy = Math.floor(rectTop / TILE);
-  const maxCy = Math.floor((rectTop + rectHeight - 1) / TILE);
-
-  if (!Number.isFinite(minCx) || !Number.isFinite(maxCx) || !Number.isFinite(minCy) || !Number.isFinite(maxCy)) return;
-
-  for (let cy = minCy; cy <= maxCy; cy++) {
-    for (let cx = minCx; cx <= maxCx; cx++) {
-      const key = monsterTileKey(cx, cy);
-      let set = MONSTER_BLOCKED_TILES.get(key);
-      if (!set) {
-        set = new Set();
-        MONSTER_BLOCKED_TILES.set(key, set);
-      }
-      set.add(state.id);
-      state.blockedTiles.add(key);
+  for (const key of tiles) {
+    let set = MONSTER_BLOCKED_TILES.get(key);
+    if (!set) {
+      set = new Set();
+      MONSTER_BLOCKED_TILES.set(key, set);
     }
+    set.add(state.id);
+    state.blockedTiles.add(key);
   }
 }
 
@@ -753,6 +776,30 @@ function applyServerPosition(id, sprite, x, y, opts = {}) {
   const absDx = Math.abs(dx);
   const absDy = Math.abs(dy);
   const dist = Math.hypot(dx, dy);
+
+  const heroTiles = HERO_BLOCK_STATE?.tiles;
+  const heroConflict = (() => {
+    if (!heroTiles || !heroTiles.size) return false;
+    const tiles = monsterFootboxTiles(state, x, y);
+    if (!tiles.length) return false;
+    for (const key of tiles) {
+      if (heroTiles.has(key)) return true;
+    }
+    return false;
+  })();
+
+  if (heroConflict) {
+    if (sprite) {
+      sprite._serverMove = null;
+      if (Number.isFinite(prevX)) sprite.x = prevX;
+      if (Number.isFinite(prevY)) sprite.y = prevY;
+    }
+    state.lastServerAt = now;
+    const backX = Number.isFinite(prevX) ? prevX : (Number.isFinite(state.x) ? state.x : x);
+    const backY = Number.isFinite(prevY) ? prevY : (Number.isFinite(state.y) ? state.y : y);
+    updateMonsterBlocking(state, backX, backY);
+    return;
+  }
 
   let segments = null;
   let tweenDur = computeTweenDuration(dx, dy);


### PR DESCRIPTION
## Summary
- restore the previous monster movement logic and reuse helpers to derive occupied tiles
- block server-driven monster moves that would overlap the hero and keep the monster at its last valid spot
- centralize monster tile calculations so dynamic blocking stays consistent for both collision checks and map updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54b96bf788327b97651b690f517a1