### PR TITLE
Ensure monster map keys fallback to spawn data

### DIFF
--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -265,7 +265,7 @@
   async function fetchAliveMonsters() {
     return (await all(`
       SELECT mi.id,
-            mi.map_key,
+            COALESCE(mi.map_key, s."mapKey") AS map_key,
             mi.x, mi.y,
             mm.attack_range,      -- tiles
             mm.aggro_range,       -- tiles

--- a/server/combat/monster_atk_simple.js
+++ b/server/combat/monster_atk_simple.js
@@ -964,7 +964,12 @@ async function resolveTileStacks({
 // ======= DB =======
 async function fetchAliveMonsters() {
   const sql = `
-    SELECT mi.id, mi.map_key, mi.x, mi.y, mi.hp, mi.hp_max,
+    SELECT mi.id,
+           COALESCE(mi.map_key, s."mapKey") AS map_key,
+           mi.x,
+           mi.y,
+           mi.hp,
+           mi.hp_max,
            s.id              AS spawn_id,
            s.x               AS sx,
            s.y               AS sy,

--- a/server/combat/pos.js
+++ b/server/combat/pos.js
@@ -187,7 +187,8 @@ function resolveCoord(raw, sizePx, spawnCoord, spawnSpan) {
 
 async function getMonsterPos(instanceId) {
   const row = await get(
-    `SELECT mi.x, mi.y, mi.map_key AS "map_key",
+    `SELECT mi.x, mi.y,
+            COALESCE(mi.map_key, s."mapKey") AS "map_key",
             COALESCE(
               NULLIF(((sp."dataJSON")::jsonb ->> 'frame_w'), '')::int,
               NULLIF(((sp."dataJSON")::jsonb ->> 'frameW'), '')::int,

--- a/server/combat/service.js
+++ b/server/combat/service.js
@@ -86,7 +86,8 @@ LEFT JOIN items_master     i ON i.key = eq.item_key
 /** Instância do monstro + dados do monstro (xp/loot/armor) */
 async function getInstanceWithMonster(instanceId) {
   return await get(
-    `SELECT mi.id, mi.hp, mi.max_hp, mi.state, mi.spawn_id, mi.map_key,
+    `SELECT mi.id, mi.hp, mi.max_hp, mi.state, mi.spawn_id,
+            COALESCE(mi.map_key, s."mapKey") AS map_key,
             mi.x, mi.y,
             m.id AS monster_id, m.key AS monster_key,
             COALESCE(m.xp,25)                      AS xp_reward,
@@ -108,6 +109,7 @@ async function getInstanceWithMonster(instanceId) {
             ) * ${TILE} AS reach_px
        FROM monster_instances mi
        JOIN monsters_master m ON m.id = mi.monster_id
+  LEFT JOIN spawns s ON s.id = mi.spawn_id
       WHERE mi.id = $1`,
     [instanceId]
   );

--- a/server/index.js
+++ b/server/index.js
@@ -985,7 +985,8 @@ async function seedAIMobsFromDB(aiMobs) {
   try {
     const rows = await all(`
       SELECT mi.id,
-             mi.x, mi.y, mi.map_key,
+             mi.x, mi.y,
+             COALESCE(mi.map_key, s."mapKey") AS map_key,
              s.x  AS sx, s.y  AS sy, s.w AS sw, s.h AS sh,
              s."monsterKey" AS monster_key,
              mm.speed        AS speed

--- a/server/respawn/worker.js
+++ b/server/respawn/worker.js
@@ -142,7 +142,7 @@ async function respawnTick({ all, run }) {
         mi.id,
         mi.max_hp                   AS mi_max_hp,
         mi.spawn_id,
-        mi.map_key,
+        COALESCE(mi.map_key, s."mapKey") AS map_key,
         s."monsterKey",
         s.x, s.y,                   -- top-left do retângulo do spawn (px)
         COALESCE(s.w, 0) AS w,
@@ -166,9 +166,12 @@ async function respawnTick({ all, run }) {
   const occupiedByMap = new Map();
   if (due.length) {
     const aliveTiles = await all(`
-      SELECT map_key, x, y
-        FROM monster_instances
-       WHERE state = 'ALIVE'
+      SELECT COALESCE(mi.map_key, s."mapKey") AS map_key,
+             mi.x,
+             mi.y
+        FROM monster_instances mi
+        LEFT JOIN spawns s ON s.id = mi.spawn_id
+       WHERE mi.state = 'ALIVE'
     `);
 
     for (const row of aliveTiles) {
@@ -187,10 +190,11 @@ async function respawnTick({ all, run }) {
       : 1;
 
     // Escolhe uma posição dentro da área do spawn (em pixels)
-    const mapKey = r.map_key == null ? '__null__' : String(r.map_key);
-    let chosen = reserveTileForSpawn(r, mapKey, occupiedByMap);
+    const resolvedMapKey = r.map_key == null ? null : String(r.map_key);
+    const occKey = resolvedMapKey ?? '__null__';
+    let chosen = reserveTileForSpawn(r, occKey, occupiedByMap);
     if (!chosen) {
-      const occ = getOccupiedTilesForMap(occupiedByMap, mapKey);
+      const occ = getOccupiedTilesForMap(occupiedByMap, occKey);
       for (let attempt = 0; attempt < 8 && !chosen; attempt++) {
         const fallbackPos = pickPosInSpawnRect(r);
         const tx = tileOf(fallbackPos.x);
@@ -231,9 +235,10 @@ async function respawnTick({ all, run }) {
               last_hit_at      = NULL,
               x                = $3,
               y                = $4,
+              map_key          = $5,
               updated_at       = now()
         WHERE id = $1`,
-      [r.id, hpFull, px, py]
+        [r.id, hpFull, px, py, resolvedMapKey]
     );
 
     try {
@@ -243,7 +248,7 @@ async function respawnTick({ all, run }) {
           id: r.id,
           x: px,
           y: py,
-          mapKey: r.map_key,
+          mapKey: resolvedMapKey,
           spawnRect: { x: r.x, y: r.y, w: r.w, h: r.h },
           monsterKey: r.monsterKey,
           speed: r.speed
@@ -256,7 +261,7 @@ async function respawnTick({ all, run }) {
       const payload = {
         type: 'monster_respawned',
         id: r.id,
-        mapKey: r.map_key,
+        mapKey: resolvedMapKey,
         monsterKey: r.monsterKey,
         spawnId: r.spawn_id,      // <-- opcional
         hp: hpFull,

--- a/server/routes/game_tick.js
+++ b/server/routes/game_tick.js
@@ -175,7 +175,8 @@ router.get('/tick', async (req, res) => {
         const combatRows = await all(
           `SELECT mi.id, mi.monster_key, mi.x, mi.y, mi.hp, mi.max_hp, mi.alive
              FROM monster_instances mi
-            WHERE mi.map_key = $1
+        LEFT JOIN spawns s ON s.id = mi.spawn_id
+            WHERE COALESCE(mi.map_key, s."mapKey") = $1
               AND mi.alive = true
             ORDER BY mi.id
             LIMIT 100`,

--- a/server/ws/initial_monsters.js
+++ b/server/ws/initial_monsters.js
@@ -38,7 +38,7 @@ async function listAliveMonsters({ mapKey: fallbackMapKey = 'house' } = {}) {
     sql: `
       SELECT
         mi.id::text                                AS id,
-        mi.map_key::text                           AS "mapKey",
+        COALESCE(mi.map_key, s."mapKey")::text    AS "mapKey",
         mi.spawn_id                                AS "spawnId",
         s."monsterKey"::text                       AS "monsterKey",
         COALESCE(mi.x, 0)                          AS x,


### PR DESCRIPTION
## Summary
- ensure all monster queries fall back to spawn map keys when instances lack map_key values
- update respawn flow to persist resolved map keys and broadcast consistent data
- align auxiliary services and snapshots with the same fallback logic for legacy rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ba3207608327bf469ea30b12f810