### PR TITLE
Fix monster adjacency search and attack cadence

### DIFF
--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -12,7 +12,10 @@
   const { hasLineOfSight } = require('./los');
   // const { inReachPx } = require('./geom');
   const { applyMobHit } = require('./service');
-  const { listFreshHeroesByMap } = require('../player/live_positions');
+  const {
+    listFreshHeroesByMap,
+    TTL_MS: LIVE_POS_TTL_MS = 1500,
+  } = require('../player/live_positions');
 
   const PX_PER_TILE = 32;
   const HOME_TOLERANCE_PX = PX_PER_TILE / 2;
@@ -33,8 +36,8 @@
   const ONLINE_RECENT_MS = 4000;       // presença considerada “viva” nos últimos 4s
 
   // Anti-hit fantasma (idades máximas aceitáveis das posições)
-  const STALE_HERO_MS = 400;           // herói precisa ter pos ≤ 400ms
-  const STALE_MOB_MS  = 800;           // mob precisa ter pos ≤ 800ms
+  const STALE_HERO_MS = Math.max(900, Number(LIVE_POS_TTL_MS) + 350);
+  const STALE_MOB_MS  = Math.max(3000, TICK_MS * 25);
 
 
   // Threat / Aggro
@@ -550,6 +553,13 @@
     { dx: 0, dy: 1 },
     { dx: 0, dy: -1 },
   ];
+  const ADJACENT_DIRS = [
+    ...CARDINAL_DIRS,
+    { dx: 1, dy: 1 },
+    { dx: 1, dy: -1 },
+    { dx: -1, dy: 1 },
+    { dx: -1, dy: -1 },
+  ];
 
   function tileKey(cx, cy) {
     return `${cx}|${cy}`;
@@ -704,7 +714,7 @@
       const node = queue.shift();
       if (node.depth >= maxDepth) continue;
 
-      for (const dir of CARDINAL_DIRS) {
+      for (const dir of ADJACENT_DIRS) {
         const nx = node.cx + dir.dx;
         const ny = node.cy + dir.dy;
         if (isSolidTile(losGrid, nx, ny)) continue;

--- a/server/combat/monster_atk_simple.js
+++ b/server/combat/monster_atk_simple.js
@@ -644,6 +644,13 @@ const CARDINAL_STEPS = [
   { dx: 0, dy: 1 },
   { dx: 0, dy: -1 },
 ];
+const ADJACENT_STEPS = [
+  ...CARDINAL_STEPS,
+  { dx: 1, dy: 1 },
+  { dx: 1, dy: -1 },
+  { dx: -1, dy: 1 },
+  { dx: -1, dy: -1 },
+];
 
 function findNearestFreeTile({
   startTx,
@@ -664,7 +671,7 @@ function findNearestFreeTile({
     const node = queue.shift();
     if (node.depth >= maxDepth) continue;
 
-    for (const step of CARDINAL_STEPS) {
+    for (const step of ADJACENT_STEPS) {
       const nx = node.tx + step.dx;
       const ny = node.ty + step.dy;
       if (!isTileInsideSpawn(nx, ny, monster)) continue;


### PR DESCRIPTION
## Summary
- allow monster stack resolution to scan diagonal neighbors when finding free tiles so aggroed mobs can occupy every adjacent spot
- relax stale position thresholds using the live position TTL and longer mob freshness so melee attack loops continue firing while monsters are stationary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cebba10c8327877ce8b48c74ea36