### PR TITLE
Guard diagonal stack resolution against corners

### DIFF
--- a/server/combat/ai-mobs.js
+++ b/server/combat/ai-mobs.js
@@ -717,6 +717,16 @@
       for (const dir of ADJACENT_DIRS) {
         const nx = node.cx + dir.dx;
         const ny = node.cy + dir.dy;
+        const isDiagonal = dir.dx !== 0 && dir.dy !== 0;
+        if (isDiagonal) {
+          const cardinalAX = node.cx + dir.dx;
+          const cardinalAY = node.cy;
+          const cardinalBX = node.cx;
+          const cardinalBY = node.cy + dir.dy;
+          if (isSolidTile(losGrid, cardinalAX, cardinalAY) && isSolidTile(losGrid, cardinalBX, cardinalBY)) {
+            continue;
+          }
+        }
         if (isSolidTile(losGrid, nx, ny)) continue;
         const k = tileKey(nx, ny);
         if (visited.has(k)) continue;

--- a/server/combat/monster_atk_simple.js
+++ b/server/combat/monster_atk_simple.js
@@ -676,6 +676,18 @@ function findNearestFreeTile({
       const ny = node.ty + step.dy;
       if (!isTileInsideSpawn(nx, ny, monster)) continue;
 
+      const isDiagonal = step.dx !== 0 && step.dy !== 0;
+      if (isDiagonal) {
+        const cornerAX = node.tx + step.dx;
+        const cornerAY = node.ty;
+        const cornerBX = node.tx;
+        const cornerBY = node.ty + step.dy;
+        if (isTileBlockedByCollision(mapCollision, cornerAX, cornerAY) &&
+            isTileBlockedByCollision(mapCollision, cornerBX, cornerBY)) {
+          continue;
+        }
+      }
+
       if (isTileBlockedByCollision(mapCollision, nx, ny)) continue;
       const key = tileKey(nx, ny);
       if (visited.has(key)) continue;


### PR DESCRIPTION
## Summary
- prevent ai mob stack resolution from traversing diagonals that are sealed by solid tiles
- block monster stack resolution diagonals when both adjacent cardinals are collidable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d14913ac8327b853045fada07ef6